### PR TITLE
feat: add lodestar vc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ You have the followin charon node artifacts generated locally under a .charon fo
 ansible-playbook -e config.beacon_node_endpoints=<beacon_node_endpoints> -i <hosts.yml> charon-node.yml
 ```
 
-### Connect the validator client
+### Validator client deployment
 
-- Update the validator client to connect to charon node API endpoint instead of the beacon node endpoint --beacon-node-api-endpoint="http://charon0:3600"
+- Set `charon_node_validator_client` in `group_vars/all.yml` (or host vars) to one of the supported clients (currently `lodestar`) to have the playbook run the matching validator role alongside charon.
+- Override Lodestar settings (`validator_lodestar_network`, `validator_lodestar_image_version`, endpoint variables, etc.) in your inventory or group vars if the defaults from `roles/validator_lodestar/defaults/main.yml` don’t match your target chain or networking layout.
 
 ### Charon Cluster
 
@@ -82,6 +83,6 @@ ansible-galaxy install -r requirements.yml
 ansible-playbook -e config.beacon_node_endpoints=<beacon_node_endpoints> -i <hosts.yml> charon-cluster.yml
 ```
 
-### Connect the validator client
+### Validator client deployment
 
-- Update each validator client to connect to charon node API endpoint instead of the beacon node endpoint --beacon-node-api-endpoint="http://charon`<node-index>`:3600"
+Refer to the Charon Node section.

--- a/charon-node.yml
+++ b/charon-node.yml
@@ -10,7 +10,7 @@
       command: docker --version
       register: docker_valid
       ignore_errors: true
-      changed_when: docker_valid != 0
+      changed_when: docker_valid.rc != 0
 
   roles:
     - name: Install Docker
@@ -18,3 +18,25 @@
       role: docker_install
     - name: Setup and run charon-node
       role: charon_node
+
+  post_tasks:
+    - name: Define available validator clients
+      ansible.builtin.set_fact:
+        __charon_node_validator_role_map:
+          lodestar: validator_lodestar
+
+    - name: Validate requested validator client
+      ansible.builtin.assert:
+        that:
+          - (charon_node_validator_client | default('')) == '' or charon_node_validator_client in __charon_node_validator_role_map
+        fail_msg: "Unsupported charon_node_validator_client '{{ charon_node_validator_client | default('', true) }}'. Supported clients: {{ __charon_node_validator_role_map.keys() | list | join(', ') }}."
+
+    - name: Run validator client '{{ charon_node_validator_client }}'
+      ansible.builtin.include_role:
+        name: "{{ __charon_node_validator_role_map[charon_node_validator_client] }}"
+      vars:
+        validator_keys_path: "{{ charon_node_validator_keys_path }}"
+        validator_api_port: "{{ charon_node_validator_api_port }}"
+        validator_node_index: "{{ node_index }}"
+        charon_network_name: "{{ charon_node_docker_network }}"
+      when: charon_node_validator_client | default('') != ''

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -95,3 +95,6 @@ synthetic_block_proposals: ''
 
 # -- Listening address (ip and port) for validator-facing traffic proxying the beacon-node API. (default "127.0.0.1:3600")
 validator_api_address: '0.0.0.0:3600'
+
+# -- Validator client to run alongside charon. Supported values: "lodestar". Leave empty to skip.
+charon_node_validator_client: ''

--- a/roles/charon_node/tasks/main.yml
+++ b/roles/charon_node/tasks/main.yml
@@ -41,6 +41,18 @@
   register: cluster_lock
   changed_when: cluster_lock.stdout != ''
 
+- name: Derive validator API port
+  ansible.builtin.set_fact:
+    __charon_node_validator_api_port: "{{ (validator_api_address | default('0.0.0.0:3600', true)).split(':')[-1] }}"
+
+- name: Set charon docker network name
+  ansible.builtin.set_fact:
+    __charon_node_docker_network: "charon-node-{{ node_index }}"
+
+- name: Ensure charon network exists
+  community.docker.docker_network:
+    name: "{{ __charon_node_docker_network }}"
+
 - name: Pull default charon image
   community.docker.docker_image:
     name: obolnetwork/charon:{{ node_image_version }}
@@ -52,6 +64,10 @@
     name: 'charon-{{ node_index }}'
     recreate: true
     command: run
+    networks:
+      - name: '{{ __charon_node_docker_network }}'
+        aliases:
+          - 'charon-{{ node_index }}'
     volumes:
       - '{{ validator_keys.stdout }}:/charon/validator_keys'
       - '{{ private_key.stdout }}:/charon/charon-enr-private-key'
@@ -88,3 +104,12 @@
       - '3610'
     ports:
       - '3610:3610'
+
+
+- name: Expose charon node shared facts
+  ansible.builtin.set_fact:
+    charon_node_validator_keys_path: "{{ validator_keys.stdout }}"
+    charon_node_private_key_path: "{{ private_key.stdout }}"
+    charon_node_cluster_lock_path: "{{ cluster_lock.stdout }}"
+    charon_node_validator_api_port: "{{ __charon_node_validator_api_port }}"
+    charon_node_docker_network: "{{ __charon_node_docker_network }}"

--- a/roles/validator_lodestar/defaults/main.yml
+++ b/roles/validator_lodestar/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+# Container image tag for Lodestar validator client
+validator_lodestar_image_version: "v1.34.1"
+
+# Target Ethereum network, e.g. "hoodi", "mainnet"
+validator_lodestar_network: "hoodi"
+
+# Whether to enable the builder API
+validator_lodestar_builder_api_enabled: false
+
+# Lodestar builder selection strategy
+validator_lodestar_builder_selection: "builderalways"
+
+# Base directory for Lodestar artifacts on the target host
+validator_lodestar_base_dir: "~/node-{{ validator_node_index }}/lodestar"
+
+# Data directory lives under the base path by default
+validator_lodestar_data_dir: "{{ validator_lodestar_base_dir }}/data"
+
+# Lodestar container name
+validator_lodestar_container_name: "lodestar-{{ validator_node_index }}"
+
+# Endpoint Lodestar uses to reach Charon's validator API
+validator_lodestar_beacon_node_address: "http://charon-{{ validator_node_index }}:{{ validator_api_port }}"

--- a/roles/validator_lodestar/files/run.sh
+++ b/roles/validator_lodestar/files/run.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+# https://github.com/ObolNetwork/charon-distributed-validator-node/blob/025027a72cd978589e402d328dd6dec946f312e3/lodestar/run.sh
+
+# Remove the existing keystores to avoid keystore locking issues.
+rm -rf /opt/data/cache /opt/data/secrets /opt/data/keystores
+
+DATA_DIR="/opt/data"
+KEYSTORES_DIR="${DATA_DIR}/keystores"
+SECRETS_DIR="${DATA_DIR}/secrets"
+
+mkdir -p "${KEYSTORES_DIR}" "${SECRETS_DIR}"
+
+IMPORTED_COUNT=0
+EXISTING_COUNT=0
+
+for f in /home/charon/validator_keys/keystore-*.json; do
+    echo "Importing key ${f}"
+
+    # Extract pubkey from keystore file
+    PUBKEY="0x$(grep '"pubkey"' "$f" | awk -F'"' '{print $4}')"
+
+    PUBKEY_DIR="${KEYSTORES_DIR}/${PUBKEY}"
+
+    # Skip import if keystore already exists
+    if [ -d "${PUBKEY_DIR}" ]; then
+        EXISTING_COUNT=$((EXISTING_COUNT + 1))
+        continue
+    fi
+
+    mkdir -p "${PUBKEY_DIR}"
+
+    # Copy the keystore file to persisted keys backend
+    install -m 600 "$f" "${PUBKEY_DIR}/voting-keystore.json"
+
+    # Copy the corresponding password file
+    PASSWORD_FILE="${f%.json}.txt"
+    install -m 600 "${PASSWORD_FILE}" "${SECRETS_DIR}/${PUBKEY}"
+
+    IMPORTED_COUNT=$((IMPORTED_COUNT + 1))
+done
+
+echo "Processed all keys imported=${IMPORTED_COUNT}, existing=${EXISTING_COUNT}, total=$(ls /home/charon/validator_keys/keystore-*.json | wc -l)"
+
+exec node /usr/app/packages/cli/bin/lodestar validator \
+    --dataDir="$DATA_DIR" \
+    --keystoresDir="$KEYSTORES_DIR" \
+    --secretsDir="$SECRETS_DIR" \
+    --network="$NETWORK" \
+    --metrics=true \
+    --metrics.address="0.0.0.0" \
+    --metrics.port=5064 \
+    --beaconNodes="$BEACON_NODE_ADDRESS" \
+    --builder="$BUILDER_API_ENABLED" \
+    --builder.selection="$BUILDER_SELECTION" \
+    --distributed

--- a/roles/validator_lodestar/tasks/main.yml
+++ b/roles/validator_lodestar/tasks/main.yml
@@ -1,0 +1,70 @@
+---
+- name: lodestar | Validate required inputs
+  ansible.builtin.assert:
+    that:
+      - validator_keys_path is defined
+      - (validator_keys_path | length) > 0
+      - validator_api_port is defined
+      - validator_node_index is defined
+      - charon_network_name is defined
+    fail_msg: 'validator_keys_path, validator_api_port, validator_node_index, and charon_network_name must be provided to the validator_lodestar role.'
+
+- name: lodestar | Ensure directories exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '750'
+  loop:
+    - "{{ validator_lodestar_base_dir }}"
+    - "{{ validator_lodestar_data_dir }}"
+
+- name: lodestar | Deploy run script
+  ansible.builtin.copy:
+    src: run.sh
+    dest: "{{ validator_lodestar_base_dir }}/run.sh"
+    mode: '755'
+
+- name: lodestar | Gather run script path
+  ansible.builtin.stat:
+    path: "{{ validator_lodestar_base_dir }}/run.sh"
+    follow: true
+  register: __validator_lodestar_run_script
+
+- name: lodestar | Gather data directory path
+  ansible.builtin.stat:
+    path: "{{ validator_lodestar_data_dir }}"
+    follow: true
+  register: __validator_lodestar_data_dir_stat
+
+- name: lodestar | Validate assets
+  ansible.builtin.assert:
+    that:
+      - __validator_lodestar_run_script.stat.exists
+      - __validator_lodestar_data_dir_stat.stat.exists
+    fail_msg: 'Lodestar run script or data directory missing; ensure files copied correctly.'
+
+- name: lodestar | Pull container image
+  community.docker.docker_image:
+    name: chainsafe/lodestar:{{ validator_lodestar_image_version }}
+    source: pull
+
+- name: lodestar | Run validator container
+  community.docker.docker_container:
+    image: chainsafe/lodestar:{{ validator_lodestar_image_version }}
+    name: "{{ validator_lodestar_container_name }}"
+    recreate: true
+    entrypoint: /opt/lodestar/run.sh
+    networks:
+      - name: '{{ charon_network_name }}'
+        aliases:
+          - 'lodestar-{{ validator_node_index }}'
+    env:
+      BEACON_NODE_ADDRESS: "{{ validator_lodestar_beacon_node_address }}"
+      NETWORK: "{{ validator_lodestar_network }}"
+      BUILDER_API_ENABLED: "{{ validator_lodestar_builder_api_enabled | bool | ternary('true', 'false') }}"
+      BUILDER_SELECTION: "{{ validator_lodestar_builder_selection }}"
+    restart_policy: unless-stopped
+    volumes:
+      - "{{ __validator_lodestar_run_script.stat.path }}:/opt/lodestar/run.sh:ro"
+      - "{{ validator_keys_path }}:/home/charon/validator_keys:ro"
+      - "{{ __validator_lodestar_data_dir_stat.stat.path }}:/opt/data"


### PR DESCRIPTION
This PR adds an additional role for `validator_lodestar` that includes the necessary defaults/files/tasks to deploy a Lodestar validator client.

It extends the `charon-node` playbook so it can support to (optionally) run a validator client along the charon client.

### Adding new validator clients
Add a new validator role under `roles/validator_<client>`, then register it in `charon-node.yml` by extending `__charon_node_validator_role_map`, i.e.
```yml
- name: Define available validator clients
      ansible.builtin.set_fact:
        __charon_node_validator_role_map:
          lodestar: validator_lodestar
          prysm: validator_prysm
```


Validation, dynamic include_role, and shared-fact plumbing are already wired to that map, so the playbook will pick up the new client automatically.

### Considerations
- Two underscore prefixes for internal variables, as per [Ansible's good practices](https://redhat-cop.github.io/automation-good-practices/#_naming_parameters).
- Lodestar's keys dir has limited `750` permissions.

### Testing

I set up a cluster on Hoodi testnet using this setup and it's running fine. See the validator [here](https://hoodi.beaconcha.in/validator/0xb60329af24ea7d8acff9583f861a8332b1633f7982668141ac31684b63f2c04624e790b33aa06476389e3666b5d9e0c4#attestations).

<img width="1595" height="679" alt="image" src="https://github.com/user-attachments/assets/305f7016-2109-4032-bbac-a3f75f8d61ea" />

ticket: #36 