### PR TITLE
add mev-boost / BN / monitoring

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,19 +6,160 @@
   "semanticCommits": "enabled",
   "enabledManagers": [
     "github-actions",
-    "regex"
+    "custom.regex"
   ],
-  "regexManagers": [
+  "customManagers": [
     {
-      "fileMatch": [
-        "^group_vars/all\\.yml$"
-      ],
-      "matchStrings": [
-        "node_image_version:\\s*['\\\"]?v?(?<currentValue>[\\w.-]+)['\\\"]?"
-      ],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "ObolNetwork/charon",
-      "versioningTemplate": "semver"
+      "customType": "regex",
+      "fileMatch": ["^group_vars/all\\.yml$"],
+      "matchStrings": ["node_image_version:\\s*['\"]?(?<currentValue>[^@\\s'\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?['\"]?"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "obolnetwork/charon",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^group_vars/all\\.yml$"],
+      "matchStrings": ["geth_version:\\s*['\"]?(?<currentValue>[^@\\s'\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?['\"]?"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "ethereum/client-go",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^group_vars/all\\.yml$"],
+      "matchStrings": ["nethermind_version:\\s*['\"]?(?<currentValue>[^@\\s'\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?['\"]?"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "nethermind/nethermind",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^group_vars/all\\.yml$"],
+      "matchStrings": ["besu_version:\\s*['\"]?(?<currentValue>[^@\\s'\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?['\"]?"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "hyperledger/besu",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^group_vars/all\\.yml$"],
+      "matchStrings": ["reth_version:\\s*['\"]?(?<currentValue>[^@\\s'\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?['\"]?"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "ghcr.io/paradigmxyz/reth",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^group_vars/all\\.yml$"],
+      "matchStrings": ["lighthouse_version:\\s*['\"]?(?<currentValue>[^@\\s'\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?['\"]?"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "sigp/lighthouse",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^group_vars/all\\.yml$"],
+      "matchStrings": ["teku_version:\\s*['\"]?(?<currentValue>[^@\\s'\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?['\"]?"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "consensys/teku",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^group_vars/all\\.yml$"],
+      "matchStrings": ["lodestar_version:\\s*['\"]?(?<currentValue>[^@\\s'\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?['\"]?"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "chainsafe/lodestar",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^group_vars/all\\.yml$"],
+      "matchStrings": ["nimbus_version:\\s*['\"]?(?<currentValue>[^@\\s'\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?['\"]?"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "statusim/nimbus-eth2",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^group_vars/all\\.yml$"],
+      "matchStrings": ["prysm_version:\\s*['\"]?(?<currentValue>[^@\\s'\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?['\"]?"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "gcr.io/prysmaticlabs/prysm/beacon-chain",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^group_vars/all\\.yml$"],
+      "matchStrings": ["grandine_version:\\s*['\"]?(?<currentValue>[^@\\s'\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?['\"]?"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "sifrai/grandine",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^group_vars/all\\.yml$"],
+      "matchStrings": ["vc_lodestar_version:\\s*['\"]?(?<currentValue>[^@\\s'\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?['\"]?"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "chainsafe/lodestar",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^group_vars/all\\.yml$"],
+      "matchStrings": ["vc_lighthouse_version:\\s*['\"]?(?<currentValue>[^@\\s'\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?['\"]?"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "sigp/lighthouse",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^group_vars/all\\.yml$"],
+      "matchStrings": ["vc_nimbus_version:\\s*['\"]?(?<currentValue>[^@\\s'\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?['\"]?"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "statusim/nimbus-validator-client",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^group_vars/all\\.yml$"],
+      "matchStrings": ["vc_prysm_version:\\s*['\"]?(?<currentValue>[^@\\s'\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?['\"]?"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "offchainlabs/prysm-validator",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^group_vars/all\\.yml$"],
+      "matchStrings": ["vc_teku_version:\\s*['\"]?(?<currentValue>[^@\\s'\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?['\"]?"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "consensys/teku",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^group_vars/all\\.yml$"],
+      "matchStrings": ["mevboost_version:\\s*['\"]?(?<currentValue>[^@\\s'\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?['\"]?"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "flashbots/mev-boost",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^group_vars/all\\.yml$"],
+      "matchStrings": ["prometheus_version:\\s*['\"]?(?<currentValue>[^@\\s'\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?['\"]?"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "prom/prometheus",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^group_vars/all\\.yml$"],
+      "matchStrings": ["alloy_version:\\s*['\"]?(?<currentValue>[^@\\s'\"]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?['\"]?"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "grafana/alloy",
+      "versioningTemplate": "docker"
     }
   ],
   "packageRules": [
@@ -42,15 +183,74 @@
     },
     {
       "matchManagers": [
-        "regex"
+        "custom.regex"
       ],
       "matchDepNames": [
-        "ObolNetwork/charon"
+        "obolnetwork/charon"
       ],
       "labels": [
         "renovate/charon"
       ],
       "groupName": "Charon image updates"
+    },
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDepNames": [
+        "ethereum/client-go",
+        "nethermind/nethermind",
+        "hyperledger/besu",
+        "ghcr.io/paradigmxyz/reth"
+      ],
+      "labels": [
+        "renovate/execution-layer"
+      ],
+      "groupName": "Execution layer client updates"
+    },
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDepNames": [
+        "sigp/lighthouse",
+        "consensys/teku",
+        "chainsafe/lodestar",
+        "statusim/nimbus-eth2",
+        "gcr.io/prysmaticlabs/prysm/beacon-chain",
+        "sifrai/grandine"
+      ],
+      "labels": [
+        "renovate/consensus-layer"
+      ],
+      "groupName": "Consensus layer client updates"
+    },
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDepNames": [
+        "statusim/nimbus-validator-client",
+        "offchainlabs/prysm-validator"
+      ],
+      "labels": [
+        "renovate/validator-client"
+      ],
+      "groupName": "Validator client updates"
+    },
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDepNames": [
+        "flashbots/mev-boost",
+        "prom/prometheus",
+        "grafana/alloy"
+      ],
+      "labels": [
+        "renovate/tools"
+      ],
+      "groupName": "Tool updates"
     }
   ]
 }

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,310 @@
+name: Smoke Tests
+
+on:
+  pull_request:
+    paths:
+      - "roles/**"
+      - "group_vars/**"
+      - "charon-*.yml"
+      - ".github/workflows/smoke-test.yml"
+  push:
+    branches: [main]
+    paths:
+      - "roles/**"
+      - "group_vars/**"
+      - "charon-*.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Lighthouse CL (3 EL variants x 3 VC)
+          - { el: geth,       cl: lighthouse, cl_port: 5052, vc: lighthouse }
+          - { el: nethermind, cl: lighthouse, cl_port: 5052, vc: lodestar }
+          - { el: reth,       cl: lighthouse, cl_port: 5052, vc: nimbus }
+          # Teku CL (2 EL x 2 VC)
+          - { el: geth,       cl: teku,       cl_port: 5052, vc: teku }
+          - { el: nethermind, cl: teku,       cl_port: 5052, vc: prysm }
+          # Lodestar CL (2 EL x 2 VC)
+          - { el: geth,       cl: lodestar,   cl_port: 5052, vc: lighthouse }
+          - { el: nethermind, cl: lodestar,   cl_port: 5052, vc: lodestar }
+          # Nimbus CL (2 EL x 2 VC)
+          - { el: besu,       cl: nimbus,     cl_port: 5052, vc: nimbus }
+          - { el: nethermind, cl: nimbus,     cl_port: 5052, vc: teku }
+          # Prysm CL (1 EL x 2 VC)
+          - { el: geth,       cl: prysm,      cl_port: 3500, vc: prysm }
+          - { el: geth,       cl: prysm,      cl_port: 3500, vc: lighthouse }
+          # Grandine CL (1 EL x 2 VC)
+          - { el: nethermind, cl: grandine,   cl_port: 5052, vc: lodestar }
+          - { el: nethermind, cl: grandine,   cl_port: 5052, vc: nimbus }
+          # Extra coverage: remaining VC/CL combos not yet tested
+          - { el: geth,       cl: lighthouse, cl_port: 5052, vc: teku }
+          - { el: geth,       cl: lighthouse, cl_port: 5052, vc: prysm }
+          - { el: geth,       cl: teku,       cl_port: 5052, vc: nimbus }
+          - { el: geth,       cl: lodestar,   cl_port: 5052, vc: prysm }
+          - { el: besu,       cl: nimbus,     cl_port: 5052, vc: lodestar }
+
+    name: "${{ matrix.cl }}-${{ matrix.el }} (vc: ${{ matrix.vc }})"
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Install Ansible
+        run: pip install "ansible-core>=2.16,<2.18" "docker>=7,<8"
+
+      - name: Install Ansible collections
+        run: ansible-galaxy install -r requirements.yml
+
+      - name: Read Charon version
+        id: charon
+        run: |
+          VER=$(grep 'node_image_version' group_vars/all.yml | sed "s/.*'\(.*\)'/\1/")
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
+          echo "Charon version: $VER"
+
+      - name: Generate Charon cluster artifacts
+        run: |
+          mkdir -p /tmp/charon
+          sudo chown 1000:1000 /tmp/charon
+          docker run --rm -v /tmp/charon:/data obolnetwork/charon:${{ steps.charon.outputs.version }} \
+            create cluster --cluster-dir=/data \
+            --name=smoke-test --nodes=3 --num-validators=1 \
+            --withdrawal-addresses=0x0000000000000000000000000000000000000000 \
+            --fee-recipient-addresses=0x0000000000000000000000000000000000000000 \
+            --network=hoodi --insecure-keys
+
+          # Copy node0 artifacts to expected location
+          sudo mkdir -p $HOME/.charon
+          sudo cp -r /tmp/charon/node0/* $HOME/.charon/
+          sudo chown -R $USER:$USER $HOME/.charon
+          echo "Artifacts:"
+          ls -la $HOME/.charon/
+          ls -la $HOME/.charon/validator_keys/
+
+      - name: Create test inventory
+        run: |
+          cat > test-hosts.yml << 'EOF'
+          all:
+            hosts:
+              localhost:
+                ansible_connection: local
+                ansible_user: runner
+          EOF
+
+      - name: Create extra vars file
+        run: |
+          cat > /tmp/smoke-vars.json << EOF
+          {
+            "beacon_node_endpoints": "http://${{ matrix.cl }}:${{ matrix.cl_port }}",
+            "deploy_beacon_node": true,
+            "execution_client": "${{ matrix.el }}",
+            "consensus_client": "${{ matrix.cl }}",
+            "beacon_network": "hoodi",
+            "deploy_validator_client": true,
+            "validator_client": "${{ matrix.vc }}",
+            "deploy_mev_boost": true,
+            "mevboost_relays": ["https://0xafa4c6985aa049fb79dd37010438cfebeb0f2bd42b115b89dd678dab0670c1de38da0c4e9138c9290a398ecd9a0b3110@boost-relay-hoodi.flashbots.net"],
+            "deploy_prometheus": true,
+            "deploy_alloy": true,
+            "alloy_loki_addresses": "http://localhost:3100/loki/api/v1/push",
+            "no_verify": "true",
+            "node_index": "0",
+            "validator_keys_dir": "${HOME}/.charon/validator_keys",
+            "private_key_file": "${HOME}/.charon/charon-enr-private-key",
+            "lock_file": "${HOME}/.charon/cluster-lock.json"
+          }
+          EOF
+          echo "Vars:"
+          cat /tmp/smoke-vars.json
+
+      - name: Run Ansible playbook
+        run: |
+          ansible-playbook -i test-hosts.yml charon-node.yml \
+            -e @/tmp/smoke-vars.json -v
+
+      - name: Wait for containers to stabilize
+        run: sleep 15
+
+      # ── Health Checks ──────────────────────────────────────────────
+
+      - name: "Check: Container status"
+        run: |
+          echo "Container status:"
+          docker ps -a --format "table {{.Names}}\t{{.Status}}"
+          echo ""
+          # Verify Ansible created all expected containers
+          EXPECTED="${{ matrix.el }} ${{ matrix.cl }} charon-0 mev-boost prometheus alloy vc-${{ matrix.vc }}-0"
+          MISSING=""
+          for svc in $EXPECTED; do
+            if ! docker ps -a --filter "name=$svc" --format '{{.Names}}' | grep -q "$svc"; then
+              MISSING="$MISSING $svc"
+            fi
+          done
+          if [ -n "$MISSING" ]; then
+            echo "::error::Ansible failed to create containers:$MISSING"
+            exit 1
+          fi
+
+          # Check container status (informational for CL/Charon/VC — they restart without synced BN)
+          echo ""
+          echo "| Container | Status | Expected |"
+          echo "|-----------|--------|----------|"
+          for svc in $(docker ps -a --format '{{.Names}}' | sort); do
+            ST=$(docker ps -a --filter "name=$svc" --format '{{.Status}}')
+            case "$svc" in
+              charon*) echo "| $svc | $ST | Exit (no synced BN) |" ;;
+              ${{ matrix.cl }}|vc-*) echo "| $svc | $ST | Up or Restarting (no synced BN) |" ;;
+              *) echo "| $svc | $ST | Up |" ;;
+            esac
+          done
+
+          # Fail only if infra containers (EL, MEV, Prometheus, Alloy) are down
+          INFRA_DOWN=""
+          for svc in ${{ matrix.el }} mev-boost prometheus alloy; do
+            ST=$(docker ps -a --filter "name=$svc" --format '{{.Status}}')
+            if echo "$ST" | grep -qE "Exited|Restarting"; then
+              INFRA_DOWN="$INFRA_DOWN $svc"
+              echo "--- $svc logs ---"
+              docker logs $svc 2>&1 | tail -10
+            fi
+          done
+          if [ -n "$INFRA_DOWN" ]; then
+            echo "::error::Infrastructure containers failed:$INFRA_DOWN"
+            exit 1
+          fi
+          echo ""
+          echo "All infrastructure containers healthy. CL/Charon/VC may restart (expected without synced BN)."
+
+      - name: "Health checks (via Docker network)"
+        run: |
+          CURL="docker run --rm --network dvnode curlimages/curl -sf"
+
+          echo "=== EL JSON-RPC ==="
+          $CURL -X POST -H "Content-Type: application/json" \
+            -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":1}' \
+            http://${{ matrix.el }}:8545 && echo " EL: OK" || echo "::warning::EL RPC not responding"
+
+          echo "=== Charon ==="
+          $CURL http://charon-0:3620/livez && echo " Charon livez: OK" || echo "::notice::Charon livez not ready (expected — BN not synced)"
+          $CURL http://charon-0:3600/eth/v1/node/version && echo " Charon API: OK" || echo "::notice::Charon API not ready (expected — BN not synced)"
+
+          echo "=== MEV-boost ==="
+          $CURL http://mev-boost:18550/eth/v1/builder/status && echo " MEV-boost: OK" || echo "::warning::MEV-boost not responding"
+
+          echo "=== Prometheus ==="
+          $CURL http://prometheus:9090/-/healthy && echo " Prometheus: OK" || echo "::warning::Prometheus not healthy"
+
+          echo "=== Alloy ==="
+          docker ps --filter name=alloy --filter status=running --format '{{.Names}}' | grep -q alloy && echo " Alloy: OK" || echo "::warning::Alloy not running"
+
+      - name: "Check: Log analysis (detect startup errors)"
+        shell: python3 {0}
+        run: |
+          import subprocess, re, sys
+
+          containers = "${{ matrix.el }} ${{ matrix.cl }} mev-boost prometheus alloy".split()
+
+          ERROR_PATTERNS = [
+              r"Unknown option", r"unknown flag", r"Possible solutions:",
+              r"unrecognized option", r"invalid argument",
+              r"ENOENT", r"No such file or directory", r"File not accessible",
+              r"file not found", r"unable to open", r"[Pp]ermission denied",
+              r"Cannot find", r"could not load", r"Failed to load",
+              r"exec format error", r"OCI runtime", r"missing required",
+              r"panic:", r"segfault",
+          ]
+
+          EXCLUDE_PATTERNS = [
+              r"please use", r"Try .* --help", r"COMMAND .* --help",
+              r"use --help to see", r"Checkpoint sync recommended",
+              r"--help for more", r"for more information",
+              r"Smartcard socket not found",
+              r"pcscd.comm",
+              r"IPC endpoint opened",
+              r"disabling",
+          ]
+
+          error_re = re.compile("|".join(ERROR_PATTERNS), re.IGNORECASE)
+          exclude_re = re.compile("|".join(EXCLUDE_PATTERNS), re.IGNORECASE)
+
+          issues = []
+
+          for name in containers:
+              try:
+                  result = subprocess.run(
+                      ["docker", "logs", name], capture_output=True, text=True, timeout=10
+                  )
+                  logs = (result.stdout + result.stderr).split("\n")[-100:]
+              except Exception:
+                  continue
+
+              errors = []
+              for line in logs:
+                  if error_re.search(line) and not exclude_re.search(line):
+                      errors.append(line.strip())
+
+              if errors:
+                  unique = list(dict.fromkeys(errors))[:5]
+                  print(f"::error::{name} has startup errors:")
+                  for e in unique:
+                      print(f"  {e}")
+                  issues.append(name)
+
+          if issues:
+              print(f"\n::error::Containers with deployment errors: {' '.join(issues)}")
+              sys.exit(1)
+          print("No startup errors detected in container logs.")
+
+      # ── Report ──────────────────────────────────────────────────────
+
+      - name: Report
+        if: always()
+        run: |
+          exec > >(tee -a "$GITHUB_STEP_SUMMARY")
+          echo "## Smoke Test: ${{ matrix.cl }}-${{ matrix.el }} (vc: ${{ matrix.vc }})"
+          echo ""
+          echo "### Containers"
+          echo '```'
+          docker ps -a --format "table {{.Names}}\t{{.Status}}" 2>/dev/null
+          echo '```'
+          echo ""
+          echo "### Health"
+          echo "| Component | Status |"
+          echo "|-----------|--------|"
+          CURL="docker run --rm --network dvnode curlimages/curl -sf -o /dev/null -w %{http_code}"
+          EL=$($CURL -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":1}' http://${{ matrix.el }}:8545 2>/dev/null || echo "FAIL")
+          CHARON=$($CURL http://charon-0:3620/livez 2>/dev/null || echo "FAIL")
+          API=$($CURL http://charon-0:3600/eth/v1/node/version 2>/dev/null || echo "FAIL")
+          MEV=$($CURL http://mev-boost:18550/eth/v1/builder/status 2>/dev/null || echo "FAIL")
+          PROM=$($CURL http://prometheus:9090/-/healthy 2>/dev/null || echo "FAIL")
+          ALLOY=$(docker ps --filter name=alloy --filter status=running --format '{{.Names}}' | grep -q alloy && echo "UP" || echo "FAIL")
+          echo "| EL (${{ matrix.el }}) | $EL |"
+          echo "| Charon livez | $CHARON |"
+          echo "| Charon validator API | $API |"
+          echo "| MEV-boost | $MEV |"
+          echo "| Prometheus | $PROM |"
+          echo "| Alloy | $ALLOY |"
+          echo ""
+          echo "### Logs"
+          for c in $(docker ps -a --format '{{.Names}}' 2>/dev/null); do
+            echo "<details><summary>$c</summary>"
+            echo ""
+            echo '```'
+            docker logs $c 2>&1 | tail -15
+            echo '```'
+            echo "</details>"
+          done
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker rm -f $(docker ps -aq) 2>/dev/null || true
+          docker network rm dvnode 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -32,45 +32,15 @@ A distributed validator node is a machine running:
 ![Distributed Validator Node](https://github.com/ObolNetwork/charon-distributed-validator-node/blob/main/DVNode.png?raw=true)
 
 ### Prerequisites
-You have the followin charon node artifacts generated locally under a .charon folder:
+You have the following charon node artifacts generated locally under a .charon folder:
 
 - validator-keys
 - charon-enr-private-key
 - cluster-lock
 
-### Run the role
+### Install dependencies
 
-```
-ansible-playbook -e config.beacon_node_endpoints=<beacon_node_endpoints> -i <hosts.yml> charon-node.yml
-```
-
-### Connect the validator client
-
-- Update the validator client to connect to charon node API endpoint instead of the beacon node endpoint --beacon-node-api-endpoint="http://charon0:3600"
-
-### Charon Cluster
-
-A distributed validator cluster is a docker-compose file with the following containers running:
-
-- Single execution layer client
-- Single consensus layer client
-- Number of Distributed Validator clients [This playbook]
-- Number of Validator clients
-- Prometheus, Grafana and Jaeger clients for monitoring this cluster.
-- Distributed Validator Cluster
-
-![Distributed Validator Cluster](https://github.com/ObolNetwork/charon-distributed-validator-cluster/blob/main/DVCluster.png?raw=true)
-
-### Prerequisites
-You have the followin charon artifacts generated locally under a .charon folder per each node:
-
-- nodeX/validator-keys
-- nodeX/charon-enr-private-key
-- nodeX/cluster-lock
-
-### Install dependancies
-
-Install the dependant ansible packages by running:
+Install the required Ansible collections:
 
 ```
 ansible-galaxy install -r requirements.yml
@@ -79,8 +49,182 @@ ansible-galaxy install -r requirements.yml
 ### Run the role
 
 ```
-ansible-playbook -e config.beacon_node_endpoints=<beacon_node_endpoints> -i <hosts.yml> charon-cluster.yml
+ansible-playbook -i <hosts.yml> charon-node.yml
 ```
+
+`beacon_node_endpoints` is required. Set it in `group_vars/all.yml` or pass it
+inline:
+
+```
+ansible-playbook -i <hosts.yml> -e beacon_node_endpoints=<beacon_node_endpoints> charon-node.yml
+```
+
+### How it works (charon_node)
+
+By default, this playbook only deploys the Charon node container. You can
+optionally enable a local beacon node pair and validator client.
+
+When enabled, the flow is:
+- Create or reuse a docker network (default: dvnode)
+- Start mev-boost (optional)
+- Start the execution client (nethermind/geth/besu/reth)
+- Start the consensus client (lighthouse/teku/lodestar/nimbus/prysm/grandine)
+- Start Charon (connected to the same network)
+- Start a validator client (lodestar/nimbus/prysm/teku)
+- Start Prometheus (optional)
+- Start Alloy (optional)
+
+### Configuration overview
+
+Set variables in `group_vars/all.yml` (or override with `-e`):
+
+- `beacon_node_endpoints`: required for Charon. Use a local client when `deploy_beacon_node: true`.
+- `deploy_beacon_node`, `execution_client`, `consensus_client`: deploy an EL/CL pair.
+- `deploy_validator_client`, `validator_client`: deploy a validator client (teku, lighthouse, lodestar, nimbus, prysm).
+- `deploy_mev_boost`, `mevboost_relays`: enable builder and relays.
+- `deploy_prometheus`, `prom_remote_write_*`: enable metrics (remote write optional).
+- `deploy_alloy`, `alloy_loki_addresses`: enable log shipping to Loki.
+
+Consensus client API ports:
+- lighthouse/teku/lodestar/nimbus/grandine: `5052`
+- prysm: `3500`
+
+### Example: use an external beacon node
+
+```
+deploy_beacon_node: false
+beacon_node_endpoints: "https://your-bn.example.com:5052"
+```
+
+### CDVN parity and optional services
+
+This playbook can optionally deploy:
+- mev-boost (builder)
+- prometheus (metrics)
+- alloy (logs)
+
+Grafana and Jaeger are still out of scope (bring your own).
+
+### Optional: deploy beacon node + validator client
+
+You can deploy an execution+consensus pair and a validator client on the same host.
+Enable the roles in `group_vars/all.yml`:
+
+```
+deploy_beacon_node: true
+execution_client: nethermind
+consensus_client: lighthouse
+
+deploy_validator_client: true
+validator_client: nimbus
+```
+
+Set `beacon_node_endpoints` to the consensus client inside Docker:
+
+```
+beacon_node_endpoints: "http://lighthouse:5052"
+```
+
+### Example: deploy full local stack (EL+CL+VC+mev-boost+observability)
+
+```
+deploy_beacon_node: true
+execution_client: nethermind
+consensus_client: lighthouse
+beacon_node_endpoints: "http://lighthouse:5052"
+
+deploy_validator_client: true
+validator_client: nimbus
+
+deploy_mev_boost: true
+mevboost_relays:
+  - https://relay.flashbots.net
+
+deploy_prometheus: true
+prom_service_owner: "dv-operator"
+prom_remote_write_enabled: true
+prom_remote_write_token: "<token>"
+
+deploy_alloy: true
+alloy_loki_addresses: "https://loki.example.com/loki/api/v1/push"
+alloy_nickname: "dvnode-1"
+```
+
+If `deploy_mev_boost` is enabled and `builder_endpoint` is empty, the beacon
+node role defaults to `http://mev-boost:18550`.
+
+Supported consensus/execution pairs (from obol-infrastructure/argocd):
+- grandine + nethermind
+- lighthouse + geth/nethermind/reth
+- lodestar + geth/nethermind
+- nimbus + besu/nethermind
+- prysm + geth
+- teku + geth/nethermind
+
+Supported validator clients:
+- lodestar
+- lighthouse
+- nimbus
+- prysm
+- teku
+
+Default validator client versions (from `group_vars/all.yml`):
+- teku v25.12.0
+- lighthouse v8.0.1
+- lodestar v1.38.0
+- nimbus v25.11.1
+- prysm v7.1.0
+
+All validator clients above are compatible with any supported consensus client.
+
+### Connect the validator client
+
+- Update the validator client to connect to charon node API endpoint instead of the beacon node endpoint --beacon-node-api-endpoint="http://charon0:3600"
+
+### Charon Cluster
+
+A distributed validator cluster is a host running:
+
+- Optional execution layer client
+- Optional consensus layer client
+- One Charon node per nodeX artifact
+- Optional validator clients
+- Optional Prometheus and Alloy (Grafana and Jaeger are out of scope)
+
+![Distributed Validator Cluster](https://github.com/ObolNetwork/charon-distributed-validator-cluster/blob/main/DVCluster.png?raw=true)
+
+### Prerequisites
+You have the following charon artifacts generated locally under a .charon folder per each node:
+
+- nodeX/validator-keys
+- nodeX/charon-enr-private-key
+- nodeX/cluster-lock
+
+### Install dependencies
+
+Install the dependent ansible packages by running:
+
+```
+ansible-galaxy install -r requirements.yml
+```
+
+### Run the role
+
+```
+ansible-playbook -i <hosts.yml> charon-cluster.yml
+```
+
+`beacon_node_endpoints` is required. Set it in `group_vars/all.yml` or pass it
+inline:
+
+```
+ansible-playbook -i <hosts.yml> -e beacon_node_endpoints=<beacon_node_endpoints> charon-cluster.yml
+```
+
+### Cluster notes
+
+- `deploy_beacon_node`, `deploy_mev_boost`, `deploy_prometheus`, and `deploy_alloy` run once per host.
+- `charon_cluster` still creates one Charon node per `nodeX` artifact.
 
 ### Connect the validator client
 

--- a/charon-cluster.yml
+++ b/charon-cluster.yml
@@ -11,7 +11,43 @@
       register: docker_valid
       ignore_errors: true
       changed_when: docker_valid != 0
+      tags:
+        - always
 
   roles:
-    - docker_install
-    - charon_cluster
+    - role: docker_install
+      tags:
+        - docker
+        - setup
+    - role: docker_network
+      tags:
+        - docker
+        - network
+        - setup
+    - role: mev_boost
+      when: deploy_mev_boost | default(false)
+      tags:
+        - mev-boost
+        - mev
+    - role: beacon_node
+      when: deploy_beacon_node | default(false)
+      tags:
+        - beacon
+        - beacon-node
+        - execution
+        - consensus
+    - role: charon_cluster
+      tags:
+        - charon
+        - charon-cluster
+    - role: prometheus
+      when: deploy_prometheus | default(false)
+      tags:
+        - prometheus
+        - monitoring
+    - role: alloy
+      when: deploy_alloy | default(false)
+      tags:
+        - alloy
+        - logging
+        - monitoring

--- a/charon-cluster.yml
+++ b/charon-cluster.yml
@@ -25,12 +25,12 @@
         - network
         - setup
     - role: mev_boost
-      when: deploy_mev_boost | default(false)
+      when: deploy_mev_boost | default(false) | bool
       tags:
         - mev-boost
         - mev
     - role: beacon_node
-      when: deploy_beacon_node | default(false)
+      when: deploy_beacon_node | default(false) | bool
       tags:
         - beacon
         - beacon-node
@@ -41,12 +41,12 @@
         - charon
         - charon-cluster
     - role: prometheus
-      when: deploy_prometheus | default(false)
+      when: deploy_prometheus | default(false) | bool
       tags:
         - prometheus
         - monitoring
     - role: alloy
-      when: deploy_alloy | default(false)
+      when: deploy_alloy | default(false) | bool
       tags:
         - alloy
         - logging

--- a/charon-node.yml
+++ b/charon-node.yml
@@ -11,10 +11,57 @@
       register: docker_valid
       ignore_errors: true
       changed_when: docker_valid != 0
+      tags:
+        - always
 
   roles:
     - name: Install Docker
       when: docker_valid.failed
       role: docker_install
+      tags:
+        - docker
+        - setup
+    - name: Ensure docker network
+      role: docker_network
+      tags:
+        - docker
+        - network
+        - setup
+    - name: Deploy mev-boost
+      role: mev_boost
+      when: deploy_mev_boost | default(false)
+      tags:
+        - mev-boost
+        - mev
+    - name: Deploy beacon node pair
+      role: beacon_node
+      when: deploy_beacon_node | default(false)
+      tags:
+        - beacon
+        - beacon-node
+        - execution
+        - consensus
     - name: Setup and run charon-node
       role: charon_node
+      tags:
+        - charon
+        - charon-node
+    - name: Deploy validator client
+      role: validator_client
+      when: deploy_validator_client | default(false)
+      tags:
+        - validator
+        - validator-client
+    - name: Deploy Prometheus
+      role: prometheus
+      when: deploy_prometheus | default(false)
+      tags:
+        - prometheus
+        - monitoring
+    - name: Deploy Alloy
+      role: alloy
+      when: deploy_alloy | default(false)
+      tags:
+        - alloy
+        - logging
+        - monitoring

--- a/charon-node.yml
+++ b/charon-node.yml
@@ -29,13 +29,13 @@
         - setup
     - name: Deploy mev-boost
       role: mev_boost
-      when: deploy_mev_boost | default(false)
+      when: deploy_mev_boost | default(false) | bool
       tags:
         - mev-boost
         - mev
     - name: Deploy beacon node pair
       role: beacon_node
-      when: deploy_beacon_node | default(false)
+      when: deploy_beacon_node | default(false) | bool
       tags:
         - beacon
         - beacon-node
@@ -48,19 +48,19 @@
         - charon-node
     - name: Deploy validator client
       role: validator_client
-      when: deploy_validator_client | default(false)
+      when: deploy_validator_client | default(false) | bool
       tags:
         - validator
         - validator-client
     - name: Deploy Prometheus
       role: prometheus
-      when: deploy_prometheus | default(false)
+      when: deploy_prometheus | default(false) | bool
       tags:
         - prometheus
         - monitoring
     - name: Deploy Alloy
       role: alloy
-      when: deploy_alloy | default(false)
+      when: deploy_alloy | default(false) | bool
       tags:
         - alloy
         - logging

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -95,3 +95,155 @@ synthetic_block_proposals: ''
 
 # -- Listening address (ip and port) for validator-facing traffic proxying the beacon-node API. (default "127.0.0.1:3600")
 validator_api_address: '0.0.0.0:3600'
+
+# Docker network shared by beacon node, charon, and validator client
+docker_network_name: 'dvnode'
+
+# Beacon node deployment
+deploy_beacon_node: false
+beacon_network: 'mainnet'
+execution_client: 'nethermind'
+consensus_client: 'lighthouse'
+checkpoint_sync_url: ''
+builder_endpoint: ''
+consensus_fee_recipient: ''
+
+# Beacon node storage
+beacon_base_dir: "/home/{{ ansible_user }}/beacon"
+beacon_data_dir: "{{ beacon_base_dir }}/data"
+beacon_jwt_dir: "{{ beacon_base_dir }}/jwt"
+beacon_jwt_file: "{{ beacon_jwt_dir }}/jwt.hex"
+
+# Execution clients
+nethermind_image: 'nethermind/nethermind'
+nethermind_version: '1.36.0'
+nethermind_p2p_port: 30303
+nethermind_http_port: 8545
+nethermind_engine_port: 8551
+
+geth_image: 'ethereum/client-go'
+geth_version: 'v1.16.8'
+geth_p2p_port: 30303
+geth_http_port: 8545
+geth_engine_port: 8551
+
+besu_image: 'hyperledger/besu'
+besu_version: '25.12.0'
+besu_p2p_port: 30303
+besu_http_port: 8545
+besu_engine_port: 8551
+
+reth_image: 'ghcr.io/paradigmxyz/reth'
+reth_version: 'v1.10.1'
+reth_p2p_port: 30303
+reth_http_port: 8545
+reth_engine_port: 8551
+
+# Consensus clients
+lighthouse_image: 'sigp/lighthouse'
+lighthouse_version: 'v8.0.1'
+lighthouse_p2p_port: 9000
+lighthouse_http_port: 5052
+lighthouse_metrics_port: 5054
+
+nimbus_image: 'statusim/nimbus-eth2'
+nimbus_version: 'multiarch-v25.11.0'
+nimbus_p2p_port: 9000
+nimbus_http_port: 5052
+nimbus_metrics_port: 5054
+nimbus_extra_args: []
+
+teku_image: 'consensys/teku'
+teku_version: '25.12.0'
+teku_p2p_port: 9000
+teku_http_port: 5052
+teku_metrics_port: 5054
+teku_extra_args: []
+
+lodestar_image: 'chainsafe/lodestar'
+lodestar_version: 'v1.38.0'
+lodestar_p2p_port: 9000
+lodestar_http_port: 5052
+lodestar_metrics_port: 5054
+lodestar_extra_args: []
+
+prysm_image: 'gcr.io/prysmaticlabs/prysm/beacon-chain'
+prysm_version: 'v7.1.2'
+prysm_p2p_port: 13000
+prysm_http_port: 3500
+prysm_extra_args: []
+
+grandine_image: 'sifrai/grandine'
+grandine_version: '2.0.1'
+grandine_p2p_port: 9000
+grandine_http_port: 5052
+grandine_metrics_port: 5054
+grandine_extra_args: []
+
+# Validator client deployment
+deploy_validator_client: false
+validator_client: 'nimbus'
+validator_beacon_node_address: "http://charon-{{ node_index }}:3600"
+validator_builder_api_enabled: 'true'
+validator_builder_selection: 'builderalways'
+validator_fee_recipient: '0x0000000000000000000000000000000000000000'
+
+vc_lodestar_image: 'chainsafe/lodestar'
+vc_lodestar_version: 'v1.38.0'
+vc_lighthouse_image: 'sigp/lighthouse'
+vc_lighthouse_version: 'v8.0.1'
+vc_lighthouse_metrics_port: 5064
+vc_nimbus_image: 'statusim/nimbus-validator-client'
+vc_nimbus_version: 'multiarch-v25.11.1'
+vc_prysm_image: 'offchainlabs/prysm-validator'
+vc_prysm_version: 'v7.1.0'
+vc_teku_image: 'consensys/teku'
+vc_teku_version: '25.12.0'
+
+validator_base_dir: "/home/{{ ansible_user }}/node-{{ node_index }}"
+validator_client_data_dir: "{{ validator_base_dir }}/vc-{{ validator_client }}"
+
+# MEV-Boost deployment
+deploy_mev_boost: false
+mevboost_container_name: 'mev-boost'
+mevboost_image: 'flashbots/mev-boost'
+mevboost_version: '1.10.1'
+mevboost_port: 18550
+mevboost_metrics_port: 18551
+mevboost_bind_address: '127.0.0.1'
+mevboost_expose_port: false
+mevboost_log_level: 'info'
+mevboost_relays: []
+
+# Prometheus deployment
+deploy_prometheus: false
+prometheus_container_name: 'prometheus'
+prometheus_image: 'prom/prometheus'
+prometheus_version: 'v3.7.3'
+prometheus_user: 'root'
+prometheus_config_dir: "/home/{{ ansible_user }}/prometheus"
+prometheus_data_dir: "{{ prometheus_config_dir }}/data"
+prometheus_port: 9090
+prometheus_bind_address: '127.0.0.1'
+prometheus_expose_port: false
+prometheus_scrape_interval: '30s'
+prometheus_evaluation_interval: '30s'
+prom_service_owner: "{{ inventory_hostname }}"
+prom_remote_write_enabled: false
+prom_remote_write_url: 'https://vm.monitoring.gcp.obol.tech/write'
+prom_remote_write_token: ''
+prom_remote_write_keep_job_regex: 'charon'
+prometheus_charon_targets:
+  - "charon-{{ node_index }}:3620"
+
+# Alloy deployment
+deploy_alloy: false
+alloy_container_name: 'alloy'
+alloy_image: 'grafana/alloy'
+alloy_version: 'v1.12.2'
+alloy_config_dir: '/etc/alloy'
+alloy_data_dir: '/var/lib/alloy'
+alloy_docker_host: 'unix:///var/run/docker.sock'
+alloy_loki_addresses: ''
+alloy_nickname: "{{ inventory_hostname }}"
+alloy_drop_unknown: true

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -116,65 +116,66 @@ beacon_jwt_file: "{{ beacon_jwt_dir }}/jwt.hex"
 
 # Execution clients
 nethermind_image: 'nethermind/nethermind'
-nethermind_version: '1.36.0'
+nethermind_version: '1.36.2'
 nethermind_p2p_port: 30303
 nethermind_http_port: 8545
 nethermind_engine_port: 8551
 
 geth_image: 'ethereum/client-go'
-geth_version: 'v1.16.8'
+geth_version: 'v1.17.2'
 geth_p2p_port: 30303
 geth_http_port: 8545
 geth_engine_port: 8551
 
 besu_image: 'hyperledger/besu'
-besu_version: '25.12.0'
+besu_version: '26.2.0'
 besu_p2p_port: 30303
 besu_http_port: 8545
 besu_engine_port: 8551
 
 reth_image: 'ghcr.io/paradigmxyz/reth'
-reth_version: 'v1.10.1'
+reth_version: 'v1.11.3'
 reth_p2p_port: 30303
 reth_http_port: 8545
 reth_engine_port: 8551
 
 # Consensus clients
 lighthouse_image: 'sigp/lighthouse'
-lighthouse_version: 'v8.0.1'
+lighthouse_version: 'v8.1.3'
 lighthouse_p2p_port: 9000
 lighthouse_http_port: 5052
 lighthouse_metrics_port: 5054
 
 nimbus_image: 'statusim/nimbus-eth2'
-nimbus_version: 'multiarch-v25.11.0'
+nimbus_version: 'multiarch-v26.3.1'
 nimbus_p2p_port: 9000
 nimbus_http_port: 5052
 nimbus_metrics_port: 5054
 nimbus_extra_args: []
 
 teku_image: 'consensys/teku'
-teku_version: '25.12.0'
+teku_version: '26.4.0'
 teku_p2p_port: 9000
 teku_http_port: 5052
 teku_metrics_port: 5054
 teku_extra_args: []
 
 lodestar_image: 'chainsafe/lodestar'
-lodestar_version: 'v1.38.0'
+lodestar_version: 'v1.41.1'
 lodestar_p2p_port: 9000
 lodestar_http_port: 5052
 lodestar_metrics_port: 5054
 lodestar_extra_args: []
 
 prysm_image: 'gcr.io/prysmaticlabs/prysm/beacon-chain'
-prysm_version: 'v7.1.2'
+prysm_version: 'v7.1.3'
 prysm_p2p_port: 13000
 prysm_http_port: 3500
+prysm_metrics_port: 8080
 prysm_extra_args: []
 
 grandine_image: 'sifrai/grandine'
-grandine_version: '2.0.1'
+grandine_version: '2.0.4'
 grandine_p2p_port: 9000
 grandine_http_port: 5052
 grandine_metrics_port: 5054
@@ -189,16 +190,16 @@ validator_builder_selection: 'builderalways'
 validator_fee_recipient: '0x0000000000000000000000000000000000000000'
 
 vc_lodestar_image: 'chainsafe/lodestar'
-vc_lodestar_version: 'v1.38.0'
+vc_lodestar_version: 'v1.41.1'
 vc_lighthouse_image: 'sigp/lighthouse'
-vc_lighthouse_version: 'v8.0.1'
+vc_lighthouse_version: 'v8.1.3'
 vc_lighthouse_metrics_port: 5064
 vc_nimbus_image: 'statusim/nimbus-validator-client'
-vc_nimbus_version: 'multiarch-v25.11.1'
+vc_nimbus_version: 'multiarch-v26.3.1'
 vc_prysm_image: 'offchainlabs/prysm-validator'
-vc_prysm_version: 'v7.1.0'
+vc_prysm_version: 'v7.1.3'
 vc_teku_image: 'consensys/teku'
-vc_teku_version: '25.12.0'
+vc_teku_version: '26.4.0'
 
 validator_base_dir: "/home/{{ ansible_user }}/node-{{ node_index }}"
 validator_client_data_dir: "{{ validator_base_dir }}/vc-{{ validator_client }}"

--- a/roles/alloy/tasks/main.yml
+++ b/roles/alloy/tasks/main.yml
@@ -1,0 +1,70 @@
+- name: Ensure docker network exists
+  community.docker.docker_network:
+    name: "{{ docker_network_name }}"
+    state: present
+  tags:
+    - alloy
+    - logging
+    - monitoring
+    - network
+
+- name: Validate Loki endpoint
+  ansible.builtin.assert:
+    that:
+      - alloy_loki_addresses is defined
+      - alloy_loki_addresses | length > 0
+    fail_msg: "alloy_loki_addresses must be set when deploy_alloy is true"
+  tags:
+    - alloy
+    - logging
+    - monitoring
+    - validation
+
+- name: Ensure Alloy directories exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0755'
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+  loop:
+    - "{{ alloy_config_dir }}"
+    - "{{ alloy_data_dir }}"
+  tags:
+    - alloy
+    - logging
+    - monitoring
+    - setup
+
+- name: Render Alloy config
+  ansible.builtin.template:
+    src: config.alloy.j2
+    dest: "{{ alloy_config_dir }}/config.alloy"
+    mode: '0644'
+  tags:
+    - alloy
+    - logging
+    - monitoring
+    - configuration
+
+- name: Deploy Alloy
+  community.docker.docker_container:
+    name: "{{ alloy_container_name }}"
+    image: "{{ alloy_image }}:{{ alloy_version }}"
+    state: started
+    restart_policy: unless-stopped
+    user: root
+    command:
+      - run
+      - /etc/alloy/config.alloy
+    volumes:
+      - "{{ alloy_config_dir }}:/etc/alloy:ro"
+      - "{{ alloy_data_dir }}:/var/lib/alloy"
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    networks:
+      - name: "{{ docker_network_name }}"
+  tags:
+    - alloy
+    - logging
+    - monitoring
+    - deploy

--- a/roles/alloy/templates/config.alloy.j2
+++ b/roles/alloy/templates/config.alloy.j2
@@ -1,0 +1,177 @@
+discovery.docker "docker" {
+	host = "{{ alloy_docker_host }}"
+}
+
+loki.process "docker" {
+	forward_to = [loki.write.default.receiver]
+
+	stage.docker { }
+}
+
+discovery.relabel "docker" {
+	targets = discovery.docker.docker.targets
+
+	rule {
+		source_labels = ["__meta_docker_container_name"]
+		regex         = "/(.*)"
+		target_label  = "container"
+	}
+
+	rule {
+		source_labels = ["container"]
+		regex         = "charon-.*"
+		target_label  = "job"
+		replacement   = "charon"
+	}
+
+	rule {
+		source_labels = ["container"]
+		regex         = "nethermind"
+		target_label  = "job"
+		replacement   = "nethermind"
+	}
+
+	rule {
+		source_labels = ["container"]
+		regex         = "geth"
+		target_label  = "job"
+		replacement   = "geth"
+	}
+
+	rule {
+		source_labels = ["container"]
+		regex         = "besu"
+		target_label  = "job"
+		replacement   = "besu"
+	}
+
+	rule {
+		source_labels = ["container"]
+		regex         = "reth"
+		target_label  = "job"
+		replacement   = "reth"
+	}
+
+	rule {
+		source_labels = ["container"]
+		regex         = "lighthouse"
+		target_label  = "job"
+		replacement   = "lighthouse"
+	}
+
+	rule {
+		source_labels = ["container"]
+		regex         = "teku"
+		target_label  = "job"
+		replacement   = "teku"
+	}
+
+	rule {
+		source_labels = ["container"]
+		regex         = "lodestar"
+		target_label  = "job"
+		replacement   = "lodestar"
+	}
+
+	rule {
+		source_labels = ["container"]
+		regex         = "nimbus"
+		target_label  = "job"
+		replacement   = "nimbus"
+	}
+
+	rule {
+		source_labels = ["container"]
+		regex         = "prysm"
+		target_label  = "job"
+		replacement   = "prysm"
+	}
+
+	rule {
+		source_labels = ["container"]
+		regex         = "grandine"
+		target_label  = "job"
+		replacement   = "grandine"
+	}
+
+	rule {
+		source_labels = ["container"]
+		regex         = "vc-lodestar-.*"
+		target_label  = "job"
+		replacement   = "vc-lodestar"
+	}
+
+	rule {
+		source_labels = ["container"]
+		regex         = "vc-nimbus-.*"
+		target_label  = "job"
+		replacement   = "vc-nimbus"
+	}
+
+	rule {
+		source_labels = ["container"]
+		regex         = "vc-prysm-.*"
+		target_label  = "job"
+		replacement   = "vc-prysm"
+	}
+
+	rule {
+		source_labels = ["container"]
+		regex         = "vc-teku-.*"
+		target_label  = "job"
+		replacement   = "vc-teku"
+	}
+
+	rule {
+		source_labels = ["container"]
+		regex         = "vc-lighthouse-.*"
+		target_label  = "job"
+		replacement   = "vc-lighthouse"
+	}
+
+	rule {
+		source_labels = ["container"]
+		regex         = "{{ mevboost_container_name | default('mev-boost') }}"
+		target_label  = "job"
+		replacement   = "mev-boost"
+	}
+
+	rule {
+		source_labels = ["container"]
+		regex         = "{{ prometheus_container_name | default('prometheus') }}"
+		target_label  = "job"
+		replacement   = "prometheus"
+	}
+
+	rule {
+		source_labels = ["container"]
+		regex         = "{{ alloy_container_name | default('alloy') }}"
+		target_label  = "job"
+		replacement   = "alloy"
+	}
+
+	{% if alloy_drop_unknown | default(true) %}
+	rule {
+		source_labels = ["job"]
+		regex         = "^$"
+		action        = "drop"
+	}
+	{% endif %}
+}
+
+loki.source.docker "docker" {
+	host          = "{{ alloy_docker_host }}"
+	targets       = discovery.docker.docker.targets
+	forward_to    = [loki.process.docker.receiver]
+	relabel_rules = discovery.relabel.docker.rules
+}
+
+loki.write "default" {
+	endpoint {
+		url = "{{ alloy_loki_addresses }}"
+	}
+	external_labels = {
+		nickname = "{{ alloy_nickname }}",
+		host     = "{{ inventory_hostname }}",
+	}
+}

--- a/roles/beacon_node/tasks/main.yml
+++ b/roles/beacon_node/tasks/main.yml
@@ -1,0 +1,460 @@
+- name: Ensure docker network exists
+  community.docker.docker_network:
+    name: "{{ docker_network_name }}"
+    state: present
+  tags:
+    - beacon
+    - beacon-node
+    - network
+
+- name: Ensure beacon directories exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0755'
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+  loop:
+    - "{{ beacon_data_dir }}"
+    - "{{ beacon_jwt_dir }}"
+    - "{{ beacon_data_dir }}/{{ execution_client }}"
+    - "{{ beacon_data_dir }}/{{ consensus_client }}"
+  tags:
+    - beacon
+    - beacon-node
+    - setup
+
+- name: Check JWT secret
+  ansible.builtin.stat:
+    path: "{{ beacon_jwt_file }}"
+  register: beacon_jwt_stat
+  tags:
+    - beacon
+    - beacon-node
+    - jwt
+
+- name: Generate JWT secret
+  ansible.builtin.shell: "openssl rand -hex 32 > {{ beacon_jwt_file }}"
+  when: not beacon_jwt_stat.stat.exists
+  changed_when: true
+  tags:
+    - beacon
+    - beacon-node
+    - jwt
+
+- name: Ensure JWT secret permissions
+  ansible.builtin.file:
+    path: "{{ beacon_jwt_file }}"
+    mode: '0600'
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+  tags:
+    - beacon
+    - beacon-node
+    - jwt
+
+- name: Default builder endpoint to mev-boost when enabled
+  ansible.builtin.set_fact:
+    builder_endpoint: "http://{{ mevboost_container_name | default('mev-boost') }}:18550"
+  when:
+    - deploy_mev_boost | default(false)
+    - builder_endpoint | default('') == ''
+  tags:
+    - beacon
+    - beacon-node
+    - configuration
+
+- name: Resolve execution engine port
+  ansible.builtin.set_fact:
+    execution_engine_port: >-
+      {{ geth_engine_port if execution_client == 'geth'
+        else besu_engine_port if execution_client == 'besu'
+        else reth_engine_port if execution_client == 'reth'
+        else nethermind_engine_port }}
+  tags:
+    - beacon
+    - beacon-node
+    - execution
+    - configuration
+
+- name: Deploy Nethermind execution client
+  community.docker.docker_container:
+    name: nethermind
+    image: "{{ nethermind_image }}:{{ nethermind_version }}"
+    state: started
+    restart_policy: unless-stopped
+    ports:
+      - "0.0.0.0:{{ nethermind_p2p_port }}:30303/tcp"
+      - "0.0.0.0:{{ nethermind_p2p_port }}:30303/udp"
+      - "127.0.0.1:{{ nethermind_http_port }}:8545"
+      - "127.0.0.1:{{ nethermind_engine_port }}:8551"
+    command: >
+      --config={{ beacon_network }}
+      --datadir=/nethermind/data
+      --HealthChecks.Enabled=true
+      --JsonRpc.Enabled=true
+      --JsonRpc.JwtSecretFile=/root/jwt/jwt.hex
+      --JsonRpc.EngineHost=0.0.0.0
+      --JsonRpc.EnginePort=8551
+      --JsonRpc.Host=0.0.0.0
+      --JsonRpc.Port=8545
+      --Metrics.Enabled=true
+      --Metrics.ExposePort=8008
+      --Sync.SnapSync=true
+      --History.Pruning=Rolling
+    volumes:
+      - "{{ beacon_data_dir }}/nethermind:/nethermind/data"
+      - "{{ beacon_jwt_dir }}:/root/jwt"
+    networks:
+      - name: "{{ docker_network_name }}"
+  when: execution_client == 'nethermind'
+  tags:
+    - beacon
+    - beacon-node
+    - execution
+    - nethermind
+    - deploy
+
+- name: Deploy Geth execution client
+  community.docker.docker_container:
+    name: geth
+    image: "{{ geth_image }}:{{ geth_version }}"
+    state: started
+    restart_policy: unless-stopped
+    ports:
+      - "0.0.0.0:{{ geth_p2p_port }}:30303/tcp"
+      - "0.0.0.0:{{ geth_p2p_port }}:30303/udp"
+      - "127.0.0.1:{{ geth_http_port }}:8545"
+      - "127.0.0.1:{{ geth_engine_port }}:8551"
+    command: >
+      --{{ beacon_network }}
+      --datadir=/geth
+      --port=30303
+      --http
+      --http.addr=0.0.0.0
+      --http.port=8545
+      --http.api=eth,net,web3
+      --http.vhosts=*
+      --authrpc.addr=0.0.0.0
+      --authrpc.port=8551
+      --authrpc.jwtsecret=/root/jwt/jwt.hex
+      --authrpc.vhosts=*
+    volumes:
+      - "{{ beacon_data_dir }}/geth:/geth"
+      - "{{ beacon_jwt_dir }}:/root/jwt"
+    networks:
+      - name: "{{ docker_network_name }}"
+  when: execution_client == 'geth'
+  tags:
+    - beacon
+    - beacon-node
+    - execution
+    - geth
+    - deploy
+
+- name: Deploy Besu execution client
+  community.docker.docker_container:
+    name: besu
+    image: "{{ besu_image }}:{{ besu_version }}"
+    state: started
+    restart_policy: unless-stopped
+    ports:
+      - "0.0.0.0:{{ besu_p2p_port }}:30303/tcp"
+      - "0.0.0.0:{{ besu_p2p_port }}:30303/udp"
+      - "127.0.0.1:{{ besu_http_port }}:8545"
+      - "127.0.0.1:{{ besu_engine_port }}:8551"
+    command: >
+      --network={{ beacon_network }}
+      --data-path=/var/lib/besu
+      --p2p-port=30303
+      --rpc-http-enabled
+      --rpc-http-host=0.0.0.0
+      --rpc-http-port=8545
+      --rpc-http-api=ETH,NET,WEB3
+      --engine-rpc-enabled
+      --engine-rpc-host=0.0.0.0
+      --engine-rpc-port=8551
+      --engine-jwt-secret=/var/lib/besu/jwt.hex
+      --host-allowlist=*
+    volumes:
+      - "{{ beacon_data_dir }}/besu:/var/lib/besu"
+      - "{{ beacon_jwt_dir }}/jwt.hex:/var/lib/besu/jwt.hex"
+    networks:
+      - name: "{{ docker_network_name }}"
+  when: execution_client == 'besu'
+  tags:
+    - beacon
+    - beacon-node
+    - execution
+    - besu
+    - deploy
+
+- name: Deploy Reth execution client
+  community.docker.docker_container:
+    name: reth
+    image: "{{ reth_image }}:{{ reth_version }}"
+    state: started
+    restart_policy: unless-stopped
+    ports:
+      - "0.0.0.0:{{ reth_p2p_port }}:30303/tcp"
+      - "0.0.0.0:{{ reth_p2p_port }}:30303/udp"
+      - "127.0.0.1:{{ reth_http_port }}:8545"
+      - "127.0.0.1:{{ reth_engine_port }}:8551"
+    command: >
+      node
+      --full
+      --chain={{ beacon_network }}
+      --datadir=/reth/data
+      --authrpc.jwtsecret=/root/jwt/jwt.hex
+      --authrpc.addr=0.0.0.0
+      --authrpc.port=8551
+      --http
+      --http.addr=0.0.0.0
+      --http.port=8545
+      --metrics=0.0.0.0:8008
+    volumes:
+      - "{{ beacon_data_dir }}/reth:/reth/data"
+      - "{{ beacon_jwt_dir }}:/root/jwt"
+    networks:
+      - name: "{{ docker_network_name }}"
+  when: execution_client == 'reth'
+  tags:
+    - beacon
+    - beacon-node
+    - execution
+    - reth
+    - deploy
+
+- name: Deploy Lighthouse consensus client
+  community.docker.docker_container:
+    name: lighthouse
+    image: "{{ lighthouse_image }}:{{ lighthouse_version }}"
+    state: started
+    restart_policy: unless-stopped
+    ports:
+      - "0.0.0.0:{{ lighthouse_p2p_port }}:9000/tcp"
+      - "0.0.0.0:{{ lighthouse_p2p_port }}:9000/udp"
+      - "127.0.0.1:{{ lighthouse_http_port }}:5052"
+      - "127.0.0.1:{{ lighthouse_metrics_port }}:5054"
+    command: >
+      lighthouse bn
+      --network={{ beacon_network }}
+      {% if checkpoint_sync_url %}--checkpoint-sync-url={{ checkpoint_sync_url }}{% endif %}
+      --checkpoint-sync-url-timeout=600
+      --execution-endpoint=http://{{ execution_client }}:{{ execution_engine_port }}
+      --execution-jwt=/opt/jwt/jwt.hex
+      --datadir=/opt/app/beacon/
+      {% if builder_endpoint %}--builder={{ builder_endpoint }}{% endif %}
+      --http
+      --http-address=0.0.0.0
+      --http-port=5052
+      --metrics
+      --metrics-address=0.0.0.0
+      --metrics-port=5054
+      --metrics-allow-origin="*"
+      {% if consensus_fee_recipient %}--suggested-fee-recipient={{ consensus_fee_recipient }}{% endif %}
+    volumes:
+      - "{{ beacon_data_dir }}/lighthouse:/opt/app/beacon"
+      - "{{ beacon_jwt_dir }}:/opt/jwt"
+    networks:
+      - name: "{{ docker_network_name }}"
+  when: consensus_client == 'lighthouse'
+  tags:
+    - beacon
+    - beacon-node
+    - consensus
+    - lighthouse
+    - deploy
+
+- name: Deploy Teku consensus client
+  community.docker.docker_container:
+    name: teku
+    image: "{{ teku_image }}:{{ teku_version }}"
+    state: started
+    restart_policy: unless-stopped
+    ports:
+      - "0.0.0.0:{{ teku_p2p_port }}:9000/tcp"
+      - "0.0.0.0:{{ teku_p2p_port }}:9000/udp"
+      - "127.0.0.1:{{ teku_http_port }}:5052"
+      - "127.0.0.1:{{ teku_metrics_port }}:5054"
+    command: >
+      --network={{ beacon_network }}
+      {% if checkpoint_sync_url %}--checkpoint-sync-url={{ checkpoint_sync_url }}{% endif %}
+      --ee-endpoint=http://{{ execution_client }}:{{ execution_engine_port }}
+      --ee-jwt-secret-file=/jwt/jwt.hex
+      --data-base-path=/opt/teku/data
+      {% if builder_endpoint %}--builder-endpoint={{ builder_endpoint }}{% endif %}
+      --rest-api-enabled=true
+      --rest-api-interface=0.0.0.0
+      --rest-api-port=5052
+      --rest-api-host-allowlist="*"
+      --metrics-enabled=true
+      --metrics-interface=0.0.0.0
+      --metrics-port=5054
+      --metrics-host-allowlist="*"
+      {% if consensus_fee_recipient %}--validators-proposer-default-fee-recipient={{ consensus_fee_recipient }}{% endif %}
+      {{ teku_extra_args | default([]) | join(' ') }}
+    volumes:
+      - "{{ beacon_data_dir }}/teku:/opt/teku/data"
+      - "{{ beacon_jwt_dir }}:/jwt:ro"
+    networks:
+      - name: "{{ docker_network_name }}"
+  when: consensus_client == 'teku'
+  tags:
+    - beacon
+    - beacon-node
+    - consensus
+    - teku
+    - deploy
+
+- name: Deploy Lodestar consensus client
+  community.docker.docker_container:
+    name: lodestar
+    image: "{{ lodestar_image }}:{{ lodestar_version }}"
+    state: started
+    restart_policy: unless-stopped
+    ports:
+      - "0.0.0.0:{{ lodestar_p2p_port }}:9000/tcp"
+      - "0.0.0.0:{{ lodestar_p2p_port }}:9000/udp"
+      - "127.0.0.1:{{ lodestar_http_port }}:5052"
+      - "127.0.0.1:{{ lodestar_metrics_port }}:5054"
+    command: >
+      beacon
+      --network={{ beacon_network }}
+      {% if checkpoint_sync_url %}--checkpointSyncUrl={{ checkpoint_sync_url }}{% endif %}
+      --execution.urls=http://{{ execution_client }}:{{ execution_engine_port }}
+      --jwt-secret=/jwt/jwt.hex
+      --dataDir=/opt/lodestar/data
+      {% if builder_endpoint %}--builder{% endif %}
+      {% if builder_endpoint %}--builder.url={{ builder_endpoint }}{% endif %}
+      --rest
+      --rest.address=0.0.0.0
+      --rest.port=5052
+      --metrics
+      --metrics.address=0.0.0.0
+      --metrics.port=5054
+      {% if consensus_fee_recipient %}--suggestedFeeRecipient={{ consensus_fee_recipient }}{% endif %}
+      {{ lodestar_extra_args | default([]) | join(' ') }}
+    volumes:
+      - "{{ beacon_data_dir }}/lodestar:/opt/lodestar/data"
+      - "{{ beacon_jwt_dir }}:/jwt:ro"
+    networks:
+      - name: "{{ docker_network_name }}"
+  when: consensus_client == 'lodestar'
+  tags:
+    - beacon
+    - beacon-node
+    - consensus
+    - lodestar
+    - deploy
+
+- name: Deploy Nimbus consensus client
+  community.docker.docker_container:
+    name: nimbus
+    image: "{{ nimbus_image }}:{{ nimbus_version }}"
+    state: started
+    restart_policy: unless-stopped
+    ports:
+      - "0.0.0.0:{{ nimbus_p2p_port }}:9000/tcp"
+      - "0.0.0.0:{{ nimbus_p2p_port }}:9000/udp"
+      - "127.0.0.1:{{ nimbus_http_port }}:5052"
+      - "127.0.0.1:{{ nimbus_metrics_port }}:5054"
+    command: >
+      --network={{ beacon_network }}
+      --data-dir=/home/user/data
+      --web3-url=http://{{ execution_client }}:{{ execution_engine_port }}
+      --jwt-secret=/jwt/jwt.hex
+      --rest
+      --rest-address=0.0.0.0
+      --rest-port=5052
+      --metrics
+      --metrics-address=0.0.0.0
+      --metrics-port=5054
+      {% if builder_endpoint %}--payload-builder-url={{ builder_endpoint }}{% endif %}
+      {% if builder_endpoint %}--payload-builder=true{% endif %}
+      {% if consensus_fee_recipient %}--suggested-fee-recipient={{ consensus_fee_recipient }}{% endif %}
+      {{ nimbus_extra_args | default([]) | join(' ') }}
+    volumes:
+      - "{{ beacon_data_dir }}/nimbus:/home/user/data"
+      - "{{ beacon_jwt_dir }}:/jwt:ro"
+    networks:
+      - name: "{{ docker_network_name }}"
+  when: consensus_client == 'nimbus'
+  tags:
+    - beacon
+    - beacon-node
+    - consensus
+    - nimbus
+    - deploy
+
+- name: Deploy Prysm consensus client
+  community.docker.docker_container:
+    name: prysm
+    image: "{{ prysm_image }}:{{ prysm_version }}"
+    state: started
+    restart_policy: unless-stopped
+    ports:
+      - "0.0.0.0:{{ prysm_p2p_port }}:13000/tcp"
+      - "0.0.0.0:{{ prysm_p2p_port }}:13000/udp"
+      - "127.0.0.1:{{ prysm_http_port }}:3500"
+    command: >
+      --accept-terms-of-use
+      --{{ beacon_network }}
+      --execution-endpoint=http://{{ execution_client }}:{{ execution_engine_port }}
+      --jwt-secret=/jwt/jwt.hex
+      --datadir=/opt/app/beacon
+      --grpc-gateway-host=0.0.0.0
+      --grpc-gateway-port=3500
+      {% if checkpoint_sync_url %}--checkpoint-sync-url={{ checkpoint_sync_url }}{% endif %}
+      {% if builder_endpoint %}--http-mev-relay={{ builder_endpoint }}{% endif %}
+      {% if consensus_fee_recipient %}--suggested-fee-recipient={{ consensus_fee_recipient }}{% endif %}
+      {{ prysm_extra_args | default([]) | join(' ') }}
+    volumes:
+      - "{{ beacon_data_dir }}/prysm:/opt/app/beacon"
+      - "{{ beacon_jwt_dir }}:/jwt:ro"
+    networks:
+      - name: "{{ docker_network_name }}"
+  when: consensus_client == 'prysm'
+  tags:
+    - beacon
+    - beacon-node
+    - consensus
+    - prysm
+    - deploy
+
+- name: Deploy Grandine consensus client
+  community.docker.docker_container:
+    name: grandine
+    image: "{{ grandine_image }}:{{ grandine_version }}"
+    state: started
+    restart_policy: unless-stopped
+    ports:
+      - "0.0.0.0:{{ grandine_p2p_port }}:9000/tcp"
+      - "0.0.0.0:{{ grandine_p2p_port }}:9000/udp"
+      - "127.0.0.1:{{ grandine_http_port }}:5052"
+      - "127.0.0.1:{{ grandine_metrics_port }}:5054"
+    command: >
+      --data-dir=/root/.grandine
+      --eth1-rpc-urls=http://{{ execution_client }}:{{ execution_engine_port }}
+      --jwt-secret=/jwt/jwt.hex
+      --http-address=0.0.0.0
+      --http-port=5052
+      --network={{ beacon_network }}
+      --metrics
+      --metrics-port=5054
+      --metrics-address=0.0.0.0
+      {% if checkpoint_sync_url %}--checkpoint-sync-url={{ checkpoint_sync_url }}{% endif %}
+      {% if builder_endpoint %}--builder-url={{ builder_endpoint }}{% endif %}
+      {{ grandine_extra_args | default([]) | join(' ') }}
+    volumes:
+      - "{{ beacon_data_dir }}/grandine:/root/.grandine"
+      - "{{ beacon_jwt_dir }}:/jwt:ro"
+    networks:
+      - name: "{{ docker_network_name }}"
+  when: consensus_client == 'grandine'
+  tags:
+    - beacon
+    - beacon-node
+    - consensus
+    - grandine
+    - deploy

--- a/roles/beacon_node/tasks/main.yml
+++ b/roles/beacon_node/tasks/main.yml
@@ -45,7 +45,7 @@
 - name: Ensure JWT secret permissions
   ansible.builtin.file:
     path: "{{ beacon_jwt_file }}"
-    mode: '0600'
+    mode: '0644'
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
   tags:
@@ -172,10 +172,10 @@
       --rpc-http-port=8545
       --rpc-http-api=ETH,NET,WEB3
       --engine-rpc-enabled
-      --engine-rpc-host=0.0.0.0
       --engine-rpc-port=8551
       --engine-jwt-secret=/var/lib/besu/jwt.hex
       --host-allowlist=*
+      --engine-host-allowlist=*
     volumes:
       - "{{ beacon_data_dir }}/besu:/var/lib/besu"
       - "{{ beacon_jwt_dir }}/jwt.hex:/var/lib/besu/jwt.hex"
@@ -397,6 +397,7 @@
       - "0.0.0.0:{{ prysm_p2p_port }}:13000/tcp"
       - "0.0.0.0:{{ prysm_p2p_port }}:13000/udp"
       - "127.0.0.1:{{ prysm_http_port }}:3500"
+      - "127.0.0.1:{{ prysm_metrics_port | default(8080) }}:8080"
     command: >
       --accept-terms-of-use
       --{{ beacon_network }}
@@ -405,6 +406,8 @@
       --datadir=/opt/app/beacon
       --grpc-gateway-host=0.0.0.0
       --grpc-gateway-port=3500
+      --monitoring-host=0.0.0.0
+      --monitoring-port=8080
       {% if checkpoint_sync_url %}--checkpoint-sync-url={{ checkpoint_sync_url }}{% endif %}
       {% if builder_endpoint %}--http-mev-relay={{ builder_endpoint }}{% endif %}
       {% if consensus_fee_recipient %}--suggested-fee-recipient={{ consensus_fee_recipient }}{% endif %}

--- a/roles/charon_cluster/tasks/main.yml
+++ b/roles/charon_cluster/tasks/main.yml
@@ -6,6 +6,10 @@
     patterns: 'node*'
   delegate_to: localhost
   register: node_folders
+  tags:
+    - charon
+    - charon-cluster
+    - discovery
 
 - name: Loop_cluster_folders
   ansible.builtin.include_role:
@@ -17,3 +21,7 @@
       private_key_file: '{{ item.1.path }}/charon-enr-private-key'
       validator_keys_dir: '{{ item.1.path }}/validator_keys/'
   with_indexed_items: '{{ node_folders.files }}'
+  tags:
+    - charon
+    - charon-cluster
+    - deploy

--- a/roles/charon_node/tasks/main.yml
+++ b/roles/charon_node/tasks/main.yml
@@ -3,6 +3,10 @@
     path: ~/node-{{ node_index }}
     state: directory
     mode: '775'
+  tags:
+    - charon
+    - charon-node
+    - setup
 
 - name: Copy validator_keys folder
   ansible.builtin.copy:
@@ -11,6 +15,11 @@
     src: '{{ validator_keys_dir }}'
     dest: ~/node-{{ node_index }}/
     mode: '777'
+  tags:
+    - charon
+    - charon-node
+    - configuration
+    - keys
 
 - name: Copy charon-enr-private-key
   ansible.builtin.copy:
@@ -18,6 +27,11 @@
     src: '{{ private_key_file }}'
     dest: ~/node-{{ node_index }}/
     mode: '777'
+  tags:
+    - charon
+    - charon-node
+    - configuration
+    - keys
 
 - name: Copy cluster-lock.json
   ansible.builtin.copy:
@@ -25,26 +39,47 @@
     src: '{{ lock_file }}'
     dest: ~/node-{{ node_index }}/
     mode: '777'
+  tags:
+    - charon
+    - charon-node
+    - configuration
 
 - name: Retrieve full path of validator keys
   ansible.builtin.command: realpath ~/node-{{ node_index }}/validator_keys
   register: validator_keys
   changed_when: validator_keys.stdout != ''
+  tags:
+    - charon
+    - charon-node
+    - configuration
 
 - name: Retrieve full path of private key
   ansible.builtin.command: realpath ~/node-{{ node_index }}/charon-enr-private-key
   register: private_key
   changed_when: private_key.stdout != ''
+  tags:
+    - charon
+    - charon-node
+    - configuration
 
 - name: Retrieve full path of cluster lock
   ansible.builtin.command: realpath ~/node-{{ node_index }}/cluster-lock.json
   register: cluster_lock
   changed_when: cluster_lock.stdout != ''
+  tags:
+    - charon
+    - charon-node
+    - configuration
 
 - name: Pull default charon image
   community.docker.docker_image:
     name: obolnetwork/charon:{{ node_image_version }}
     source: pull
+  tags:
+    - charon
+    - charon-node
+    - docker
+    - pull
 
 - name: Create charon container
   community.docker.docker_container:
@@ -88,3 +123,9 @@
       - '3610'
     ports:
       - '3610:3610'
+    networks:
+      - name: "{{ docker_network_name }}"
+  tags:
+    - charon
+    - charon-node
+    - deploy

--- a/roles/charon_node/tasks/main.yml
+++ b/roles/charon_node/tasks/main.yml
@@ -14,7 +14,7 @@
     directory_mode: true
     src: '{{ validator_keys_dir }}'
     dest: ~/node-{{ node_index }}/
-    mode: '777'
+    mode: '600'
   tags:
     - charon
     - charon-node
@@ -26,7 +26,7 @@
     remote_src: false
     src: '{{ private_key_file }}'
     dest: ~/node-{{ node_index }}/
-    mode: '777'
+    mode: '600'
   tags:
     - charon
     - charon-node
@@ -38,7 +38,7 @@
     remote_src: false
     src: '{{ lock_file }}'
     dest: ~/node-{{ node_index }}/
-    mode: '777'
+    mode: '644'
   tags:
     - charon
     - charon-node
@@ -47,7 +47,7 @@
 - name: Retrieve full path of validator keys
   ansible.builtin.command: realpath ~/node-{{ node_index }}/validator_keys
   register: validator_keys
-  changed_when: validator_keys.stdout != ''
+  changed_when: false
   tags:
     - charon
     - charon-node
@@ -56,7 +56,7 @@
 - name: Retrieve full path of private key
   ansible.builtin.command: realpath ~/node-{{ node_index }}/charon-enr-private-key
   register: private_key
-  changed_when: private_key.stdout != ''
+  changed_when: false
   tags:
     - charon
     - charon-node
@@ -65,7 +65,7 @@
 - name: Retrieve full path of cluster lock
   ansible.builtin.command: realpath ~/node-{{ node_index }}/cluster-lock.json
   register: cluster_lock
-  changed_when: cluster_lock.stdout != ''
+  changed_when: false
   tags:
     - charon
     - charon-node
@@ -85,7 +85,7 @@
   community.docker.docker_container:
     image: obolnetwork/charon:{{ node_image_version }}
     name: 'charon-{{ node_index }}'
-    recreate: true
+    recreate: false
     command: run
     volumes:
       - '{{ validator_keys.stdout }}:/charon/validator_keys'

--- a/roles/docker_install/tasks/main.yml
+++ b/roles/docker_install/tasks/main.yml
@@ -2,14 +2,23 @@
   apt_key:
     url: https://download.docker.com/linux/ubuntu/gpg
     state: present
+  tags:
+    - docker
+    - setup
 
 - name: Add Docker Repository
   apt_repository:
     repo: deb https://download.docker.com/linux/ubuntu focal stable
     state: present
+  tags:
+    - docker
+    - setup
 
 - name: Update apt and install docker-ce
   apt:
     name: docker-ce
     state: latest
     update_cache: true
+  tags:
+    - docker
+    - setup

--- a/roles/docker_install/tasks/main.yml
+++ b/roles/docker_install/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: Add Docker Repository
   apt_repository:
-    repo: deb https://download.docker.com/linux/ubuntu focal stable
+    repo: "deb https://download.docker.com/linux/ubuntu {{ ansible_distribution_release | default('jammy') }} stable"
     state: present
   tags:
     - docker

--- a/roles/docker_network/tasks/main.yml
+++ b/roles/docker_network/tasks/main.yml
@@ -1,0 +1,8 @@
+- name: Ensure docker network exists
+  community.docker.docker_network:
+    name: "{{ docker_network_name }}"
+    state: present
+  tags:
+    - docker
+    - network
+    - setup

--- a/roles/mev_boost/tasks/main.yml
+++ b/roles/mev_boost/tasks/main.yml
@@ -1,0 +1,48 @@
+- name: Ensure docker network exists
+  community.docker.docker_network:
+    name: "{{ docker_network_name }}"
+    state: present
+  tags:
+    - mev-boost
+    - mev
+    - network
+
+- name: Validate mev-boost relays
+  ansible.builtin.assert:
+    that:
+      - mevboost_relays is defined
+      - mevboost_relays | length > 0
+    fail_msg: "mevboost_relays must be set when deploy_mev_boost is true"
+  tags:
+    - mev-boost
+    - mev
+    - validation
+
+- name: Normalize mev-boost relays
+  ansible.builtin.set_fact:
+    mevboost_relays_value: "{{ mevboost_relays if mevboost_relays is string else mevboost_relays | join(',') }}"
+  tags:
+    - mev-boost
+    - mev
+    - configuration
+
+- name: Deploy mev-boost
+  community.docker.docker_container:
+    name: "{{ mevboost_container_name }}"
+    image: "{{ mevboost_image }}:{{ mevboost_version }}"
+    state: started
+    restart_policy: unless-stopped
+    ports: "{{ [mevboost_bind_address ~ ':' ~ mevboost_port ~ ':18550'] if mevboost_expose_port | default(false) else omit }}"
+    command: >-
+      -{{ beacon_network }}
+      -loglevel={{ mevboost_log_level }}
+      -addr=0.0.0.0:18550
+      {{ '-metrics -metrics-addr=0.0.0.0:' ~ mevboost_metrics_port if mevboost_metrics_port | default('') else '' }}
+      -relay-check
+      -relays={{ mevboost_relays_value }}
+    networks:
+      - name: "{{ docker_network_name }}"
+  tags:
+    - mev-boost
+    - mev
+    - deploy

--- a/roles/prometheus/tasks/main.yml
+++ b/roles/prometheus/tasks/main.yml
@@ -1,0 +1,66 @@
+- name: Ensure docker network exists
+  community.docker.docker_network:
+    name: "{{ docker_network_name }}"
+    state: present
+  tags:
+    - prometheus
+    - monitoring
+    - network
+
+- name: Validate remote write settings
+  ansible.builtin.assert:
+    that:
+      - prom_remote_write_url | length > 0
+      - prom_remote_write_token | length > 0
+    fail_msg: "prom_remote_write_url and prom_remote_write_token must be set when prom_remote_write_enabled is true"
+  when: prom_remote_write_enabled | default(false)
+  tags:
+    - prometheus
+    - monitoring
+    - validation
+
+- name: Ensure Prometheus directories exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0755'
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+  loop:
+    - "{{ prometheus_config_dir }}"
+    - "{{ prometheus_data_dir }}"
+  tags:
+    - prometheus
+    - monitoring
+    - setup
+
+- name: Render Prometheus config
+  ansible.builtin.template:
+    src: prometheus.yml.j2
+    dest: "{{ prometheus_config_dir }}/prometheus.yml"
+    mode: '0644'
+  tags:
+    - prometheus
+    - monitoring
+    - configuration
+
+- name: Deploy Prometheus
+  community.docker.docker_container:
+    name: "{{ prometheus_container_name }}"
+    image: "{{ prometheus_image }}:{{ prometheus_version }}"
+    state: started
+    restart_policy: unless-stopped
+    user: "{{ prometheus_user }}"
+    ports: "{{ [prometheus_bind_address ~ ':' ~ prometheus_port ~ ':9090'] if prometheus_expose_port | default(false) else omit }}"
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+    volumes:
+      - "{{ prometheus_config_dir }}/prometheus.yml:/etc/prometheus/prometheus.yml:ro"
+      - "{{ prometheus_data_dir }}:/prometheus"
+    networks:
+      - name: "{{ docker_network_name }}"
+  tags:
+    - prometheus
+    - monitoring
+    - deploy

--- a/roles/prometheus/templates/prometheus.yml.j2
+++ b/roles/prometheus/templates/prometheus.yml.j2
@@ -1,0 +1,66 @@
+global:
+  scrape_interval: {{ prometheus_scrape_interval }}
+  evaluation_interval: {{ prometheus_evaluation_interval }}
+  external_labels:
+    service_owner: "{{ prom_service_owner }}"
+
+{% if prom_remote_write_enabled | default(false) %}
+remote_write:
+  - url: "{{ prom_remote_write_url }}"
+    authorization:
+      credentials: "{{ prom_remote_write_token }}"
+    {% if prom_remote_write_keep_job_regex %}
+    write_relabel_configs:
+      - source_labels: [job]
+        regex: "{{ prom_remote_write_keep_job_regex }}"
+        action: keep
+    {% endif %}
+
+{% endif %}
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["{{ prometheus_container_name }}:9090"]
+  - job_name: "charon"
+    static_configs:
+      - targets: {{ prometheus_charon_targets | to_json }}
+{% if execution_client == 'nethermind' %}
+  - job_name: "nethermind"
+    static_configs:
+      - targets: ["nethermind:8008"]
+{% endif %}
+{% if execution_client == 'reth' %}
+  - job_name: "reth"
+    static_configs:
+      - targets: ["reth:8008"]
+{% endif %}
+{% if consensus_client == 'lighthouse' %}
+  - job_name: "lighthouse"
+    static_configs:
+      - targets: ["lighthouse:{{ lighthouse_metrics_port }}"]
+{% endif %}
+{% if consensus_client == 'teku' %}
+  - job_name: "teku"
+    static_configs:
+      - targets: ["teku:{{ teku_metrics_port }}"]
+{% endif %}
+{% if consensus_client == 'lodestar' %}
+  - job_name: "lodestar"
+    static_configs:
+      - targets: ["lodestar:{{ lodestar_metrics_port }}"]
+{% endif %}
+{% if consensus_client == 'nimbus' %}
+  - job_name: "nimbus"
+    static_configs:
+      - targets: ["nimbus:{{ nimbus_metrics_port }}"]
+{% endif %}
+{% if consensus_client == 'grandine' %}
+  - job_name: "grandine"
+    static_configs:
+      - targets: ["grandine:{{ grandine_metrics_port }}"]
+{% endif %}
+{% if deploy_mev_boost | default(false) and mevboost_metrics_port | default('') %}
+  - job_name: "mev-boost"
+    static_configs:
+      - targets: ["{{ mevboost_container_name }}:{{ mevboost_metrics_port }}"]
+{% endif %}

--- a/roles/validator_client/files/lighthouse-run.sh
+++ b/roles/validator_client/files/lighthouse-run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DATA_DIR="/opt/lighthouse"
+VALIDATOR_KEYS_DIR="/opt/charon/validator_keys"
+
+mkdir -p "${DATA_DIR}"
+
+for f in "${VALIDATOR_KEYS_DIR}"/keystore-*.json; do
+    [ -f "$f" ] || continue
+    echo "Importing key ${f}"
+    lighthouse --network "${NETWORK}" account validator import \
+        --reuse-password \
+        --keystore "$f" \
+        --password-file "${f%.json}.txt" \
+        --validators-dir "${DATA_DIR}"
+done
+
+builder_args=""
+if [ "${BUILDER_API_ENABLED:-false}" = "true" ]; then
+    builder_args="--builder-proposals"
+fi
+
+exec lighthouse --network "${NETWORK}" validator \
+    --beacon-nodes "${BEACON_NODE_ADDRESS}" \
+    --validators-dir "${DATA_DIR}" \
+    --suggested-fee-recipient "${FEE_RECIPIENT}" \
+    --metrics \
+    --metrics-address "0.0.0.0" \
+    --metrics-port "${LIGHTHOUSE_METRICS_PORT}" \
+    --use-long-timeouts \
+    --distributed \
+    ${builder_args}

--- a/roles/validator_client/files/lighthouse-run.sh
+++ b/roles/validator_client/files/lighthouse-run.sh
@@ -28,6 +28,7 @@ exec lighthouse --network "${NETWORK}" validator \
     --metrics \
     --metrics-address "0.0.0.0" \
     --metrics-port "${LIGHTHOUSE_METRICS_PORT}" \
+    --init-slashing-protection \
     --use-long-timeouts \
     --distributed \
     ${builder_args}

--- a/roles/validator_client/files/lodestar-run.sh
+++ b/roles/validator_client/files/lodestar-run.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# Remove the existing keystores to avoid keystore locking issues.
+rm -rf /opt/data/cache /opt/data/secrets /opt/data/keystores
+
+DATA_DIR="/opt/data"
+KEYSTORES_DIR="${DATA_DIR}/keystores"
+SECRETS_DIR="${DATA_DIR}/secrets"
+
+mkdir -p "${KEYSTORES_DIR}" "${SECRETS_DIR}"
+
+IMPORTED_COUNT=0
+EXISTING_COUNT=0
+
+for f in /home/charon/validator_keys/keystore-*.json; do
+    echo "Importing key ${f}"
+
+    # Extract pubkey from keystore file
+    PUBKEY="0x$(grep '\"pubkey\"' "$f" | awk -F'\"' '{print $4}')"
+
+    PUBKEY_DIR="${KEYSTORES_DIR}/${PUBKEY}"
+
+    # Skip import if keystore already exists
+    if [ -d "${PUBKEY_DIR}" ]; then
+        EXISTING_COUNT=$((EXISTING_COUNT + 1))
+        continue
+    fi
+
+    mkdir -p "${PUBKEY_DIR}"
+
+    # Copy the keystore file to persisted keys backend
+    install -m 600 "$f" "${PUBKEY_DIR}/voting-keystore.json"
+
+    # Copy the corresponding password file
+    PASSWORD_FILE="${f%.json}.txt"
+    install -m 600 "${PASSWORD_FILE}" "${SECRETS_DIR}/${PUBKEY}"
+
+    IMPORTED_COUNT=$((IMPORTED_COUNT + 1))
+done
+
+echo "Processed all keys imported=${IMPORTED_COUNT}, existing=${EXISTING_COUNT}, total=$(ls /home/charon/validator_keys/keystore-*.json | wc -l)"
+
+exec node /usr/app/packages/cli/bin/lodestar validator \
+    --dataDir="$DATA_DIR" \
+    --keystoresDir="$KEYSTORES_DIR" \
+    --secretsDir="$SECRETS_DIR" \
+    --network="$NETWORK" \
+    --metrics=true \
+    --metrics.address="0.0.0.0" \
+    --metrics.port=5064 \
+    --beaconNodes="$BEACON_NODE_ADDRESS" \
+    --builder="$BUILDER_API_ENABLED" \
+    --builder.selection="$BUILDER_SELECTION" \
+    --distributed

--- a/roles/validator_client/files/nimbus-run.sh
+++ b/roles/validator_client/files/nimbus-run.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Cleanup nimbus directories if they already exist.
+rm -rf /home/user/data
+
+# Running a nimbus VC involves two steps which need to run in order:
+# 1. Importing the validator keys
+# 2. And then actually running the VC
+tmpkeys="/home/validator_keys/tmpkeys"
+mkdir -p ${tmpkeys}
+
+for f in /home/validator_keys/keystore-*.json; do
+  echo "Importing key ${f}"
+
+  # Read password from keystore-*.txt into $password variable.
+  password=$(<"${f//json/txt}")
+
+  # Copy keystore file to tmpkeys/ directory.
+  cp "${f}" "${tmpkeys}"
+
+  # Import keystore with the password.
+  echo "$password" |
+    /home/user/nimbus_beacon_node deposits import \
+      --data-dir=/home/user/data \
+      /home/validator_keys/tmpkeys
+
+  # Delete tmpkeys/keystore-*.json file that was copied before.
+  filename="$(basename ${f})"
+  rm "${tmpkeys}/${filename}"
+done
+
+# Delete the tmpkeys/ directory since it's no longer needed.
+rm -r ${tmpkeys}
+
+echo "Imported all keys"
+
+# Now run nimbus VC
+exec /home/user/nimbus_validator_client \
+  --data-dir=/home/user/data \
+  --beacon-node="${BEACON_NODE_ADDRESS}" \
+  --doppelganger-detection=false \
+  --metrics \
+  --metrics-address=0.0.0.0 \
+  --payload-builder=${BUILDER_API_ENABLED} \
+  --distributed

--- a/roles/validator_client/files/nimbus-run.sh
+++ b/roles/validator_client/files/nimbus-run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Cleanup nimbus directories if they already exist.
-rm -rf /home/user/data
+rm -rf /home/user/data/validators /home/user/data/db
 
 # Running a nimbus VC involves two steps which need to run in order:
 # 1. Importing the validator keys

--- a/roles/validator_client/files/prysm-run.sh
+++ b/roles/validator_client/files/prysm-run.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+WALLET_DIR="/prysm-wallet"
+
+# Cleanup wallet directories if already exists.
+rm -rf $WALLET_DIR
+mkdir $WALLET_DIR
+
+# Running a prysm VC involves two steps which need to run in order:
+# 1. Import validator keys in a prysm wallet account.
+# 2. Run the validator client.
+WALLET_PASSWORD="prysm-validator-secret"
+echo $WALLET_PASSWORD > /wallet-password.txt
+/app/cmd/validator/validator wallet create --accept-terms-of-use --wallet-password-file=wallet-password.txt --keymanager-kind=direct --wallet-dir="$WALLET_DIR"
+
+tmpkeys="/home/charon/validator_keys/tmpkeys"
+mkdir -p ${tmpkeys}
+
+for f in /home/charon/validator_keys/keystore-*.json; do
+    echo "Importing key ${f}"
+
+    # Copy keystore file to tmpkeys/ directory.
+    cp "${f}" "${tmpkeys}"
+
+    # Import keystore with password.
+    /app/cmd/validator/validator accounts import \
+        --accept-terms-of-use=true \
+        --wallet-dir="$WALLET_DIR" \
+        --keys-dir="${tmpkeys}" \
+        --account-password-file="${f//json/txt}" \
+        --wallet-password-file=wallet-password.txt
+
+    # Delete tmpkeys/keystore-*.json file that was copied before.
+    filename="$(basename ${f})"
+    rm "${tmpkeys}/${filename}"
+done
+
+# Delete the tmpkeys/ directory since it's no longer needed.
+rm -r ${tmpkeys}
+
+echo "Imported all keys"
+
+# Now run prysm VC
+/app/cmd/validator/validator --wallet-dir="$WALLET_DIR" \
+    --accept-terms-of-use=true \
+    --datadir="/data/vc" \
+    --wallet-password-file="/wallet-password.txt" \
+    --enable-beacon-rest-api \
+    --beacon-rest-api-provider="${BEACON_NODE_ADDRESS}" \
+    --beacon-rpc-provider="${BEACON_NODE_ADDRESS}" \
+    --"${NETWORK}" \
+    --distributed

--- a/roles/validator_client/files/prysm-run.sh
+++ b/roles/validator_client/files/prysm-run.sh
@@ -9,8 +9,9 @@ mkdir $WALLET_DIR
 # Running a prysm VC involves two steps which need to run in order:
 # 1. Import validator keys in a prysm wallet account.
 # 2. Run the validator client.
-WALLET_PASSWORD="prysm-validator-secret"
+WALLET_PASSWORD="${PRYSM_WALLET_PASSWORD:-prysm-validator-secret}"
 echo $WALLET_PASSWORD > /wallet-password.txt
+chmod 600 /wallet-password.txt
 /app/cmd/validator/validator wallet create --accept-terms-of-use --wallet-password-file=wallet-password.txt --keymanager-kind=direct --wallet-dir="$WALLET_DIR"
 
 tmpkeys="/home/charon/validator_keys/tmpkeys"
@@ -41,12 +42,10 @@ rm -r ${tmpkeys}
 echo "Imported all keys"
 
 # Now run prysm VC
-/app/cmd/validator/validator --wallet-dir="$WALLET_DIR" \
+exec /app/cmd/validator/validator --wallet-dir="$WALLET_DIR" \
     --accept-terms-of-use=true \
     --datadir="/data/vc" \
     --wallet-password-file="/wallet-password.txt" \
-    --enable-beacon-rest-api \
     --beacon-rest-api-provider="${BEACON_NODE_ADDRESS}" \
-    --beacon-rpc-provider="${BEACON_NODE_ADDRESS}" \
     --"${NETWORK}" \
     --distributed

--- a/roles/validator_client/tasks/main.yml
+++ b/roles/validator_client/tasks/main.yml
@@ -1,0 +1,213 @@
+- name: Ensure docker network exists
+  community.docker.docker_network:
+    name: "{{ docker_network_name }}"
+    state: present
+  tags:
+    - validator
+    - validator-client
+    - network
+
+- name: Set validator client defaults
+  ansible.builtin.set_fact:
+    validator_client_container_name: "{{ validator_client_container_name | default('vc-' ~ validator_client ~ '-' ~ node_index) }}"
+    validator_beacon_node_address: "{{ validator_beacon_node_address | default('http://charon-' ~ node_index ~ ':3600') }}"
+    validator_keys_path: "{{ validator_base_dir }}/validator_keys"
+  tags:
+    - validator
+    - validator-client
+    - configuration
+
+- name: Ensure validator client directories exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0755'
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+  loop:
+    - "{{ validator_client_data_dir }}"
+  tags:
+    - validator
+    - validator-client
+    - setup
+
+- name: Copy Lodestar VC run script
+  ansible.builtin.copy:
+    src: lodestar-run.sh
+    dest: "{{ validator_client_data_dir }}/lodestar-run.sh"
+    mode: '0755'
+  when: validator_client == 'lodestar'
+  tags:
+    - validator
+    - validator-client
+    - lodestar
+    - configuration
+
+- name: Copy Nimbus VC run script
+  ansible.builtin.copy:
+    src: nimbus-run.sh
+    dest: "{{ validator_client_data_dir }}/nimbus-run.sh"
+    mode: '0755'
+  when: validator_client == 'nimbus'
+  tags:
+    - validator
+    - validator-client
+    - nimbus
+    - configuration
+
+- name: Copy Prysm VC run script
+  ansible.builtin.copy:
+    src: prysm-run.sh
+    dest: "{{ validator_client_data_dir }}/prysm-run.sh"
+    mode: '0755'
+  when: validator_client == 'prysm'
+  tags:
+    - validator
+    - validator-client
+    - prysm
+    - configuration
+
+- name: Copy Lighthouse VC run script
+  ansible.builtin.copy:
+    src: lighthouse-run.sh
+    dest: "{{ validator_client_data_dir }}/lighthouse-run.sh"
+    mode: '0755'
+  when: validator_client == 'lighthouse'
+  tags:
+    - validator
+    - validator-client
+    - lighthouse
+    - configuration
+
+- name: Deploy Lodestar validator client
+  community.docker.docker_container:
+    name: "{{ validator_client_container_name }}"
+    image: "{{ vc_lodestar_image }}:{{ vc_lodestar_version }}"
+    state: started
+    restart_policy: unless-stopped
+    entrypoint: /opt/lodestar/run.sh
+    env:
+      BEACON_NODE_ADDRESS: "{{ validator_beacon_node_address }}"
+      NETWORK: "{{ beacon_network }}"
+      BUILDER_API_ENABLED: "{{ validator_builder_api_enabled }}"
+      BUILDER_SELECTION: "{{ validator_builder_selection }}"
+    volumes:
+      - "{{ validator_client_data_dir }}/lodestar-run.sh:/opt/lodestar/run.sh"
+      - "{{ validator_keys_path }}:/home/charon/validator_keys"
+      - "{{ validator_client_data_dir }}:/opt/data"
+    networks:
+      - name: "{{ docker_network_name }}"
+  when: validator_client == 'lodestar'
+  tags:
+    - validator
+    - validator-client
+    - lodestar
+    - deploy
+
+- name: Deploy Nimbus validator client
+  community.docker.docker_container:
+    name: "{{ validator_client_container_name }}"
+    image: "{{ vc_nimbus_image }}:{{ vc_nimbus_version }}"
+    state: started
+    restart_policy: unless-stopped
+    entrypoint: /home/user/data/run.sh
+    env:
+      BEACON_NODE_ADDRESS: "{{ validator_beacon_node_address }}"
+      BUILDER_API_ENABLED: "{{ validator_builder_api_enabled }}"
+    volumes:
+      - "{{ validator_client_data_dir }}/nimbus-run.sh:/home/user/data/run.sh"
+      - "{{ validator_keys_path }}:/home/validator_keys"
+      - "{{ validator_client_data_dir }}:/home/user/data"
+    networks:
+      - name: "{{ docker_network_name }}"
+  when: validator_client == 'nimbus'
+  tags:
+    - validator
+    - validator-client
+    - nimbus
+    - deploy
+
+- name: Deploy Prysm validator client
+  community.docker.docker_container:
+    name: "{{ validator_client_container_name }}"
+    image: "{{ vc_prysm_image }}:{{ vc_prysm_version }}"
+    state: started
+    restart_policy: unless-stopped
+    entrypoint: /home/prysm/run.sh
+    env:
+      BEACON_NODE_ADDRESS: "{{ validator_beacon_node_address }}"
+      NETWORK: "{{ beacon_network }}"
+    volumes:
+      - "{{ validator_client_data_dir }}/prysm-run.sh:/home/prysm/run.sh"
+      - "{{ validator_keys_path }}:/home/charon/validator_keys"
+      - "{{ validator_client_data_dir }}:/data/vc"
+    networks:
+      - name: "{{ docker_network_name }}"
+  when: validator_client == 'prysm'
+  tags:
+    - validator
+    - validator-client
+    - prysm
+    - deploy
+
+- name: Deploy Teku validator client
+  community.docker.docker_container:
+    name: "{{ validator_client_container_name }}"
+    image: "{{ vc_teku_image }}:{{ vc_teku_version }}"
+    state: started
+    restart_policy: unless-stopped
+    command:
+      - validator-client
+      - --beacon-node-api-endpoint
+      - "{{ validator_beacon_node_address }}"
+      - --network
+      - "{{ beacon_network }}"
+      - --data-base-path=/home/data
+      - --validator-keys=/opt/charon/validator_keys:/opt/charon/validator_keys
+      - --validators-keystore-locking-enabled
+      - "false"
+      - --validators-external-signer-slashing-protection-enabled
+      - "true"
+      - --validators-builder-registration-default-enabled
+      - "{{ validator_builder_api_enabled }}"
+      - --validators-proposer-default-fee-recipient
+      - "{{ validator_fee_recipient }}"
+      - --Xobol-dvt-integration-enabled
+      - "true"
+    volumes:
+      - "{{ validator_keys_path }}:/opt/charon/validator_keys"
+      - "{{ validator_client_data_dir }}:/home/data"
+    networks:
+      - name: "{{ docker_network_name }}"
+  when: validator_client == 'teku'
+  tags:
+    - validator
+    - validator-client
+    - teku
+    - deploy
+
+- name: Deploy Lighthouse validator client
+  community.docker.docker_container:
+    name: "{{ validator_client_container_name }}"
+    image: "{{ vc_lighthouse_image }}:{{ vc_lighthouse_version }}"
+    state: started
+    restart_policy: unless-stopped
+    entrypoint: /opt/lighthouse/run.sh
+    env:
+      BEACON_NODE_ADDRESS: "{{ validator_beacon_node_address }}"
+      NETWORK: "{{ beacon_network }}"
+      BUILDER_API_ENABLED: "{{ validator_builder_api_enabled }}"
+      FEE_RECIPIENT: "{{ validator_fee_recipient }}"
+      LIGHTHOUSE_METRICS_PORT: "{{ vc_lighthouse_metrics_port }}"
+    volumes:
+      - "{{ validator_client_data_dir }}/lighthouse-run.sh:/opt/lighthouse/run.sh"
+      - "{{ validator_keys_path }}:/opt/charon/validator_keys"
+      - "{{ validator_client_data_dir }}:/opt/lighthouse"
+    networks:
+      - name: "{{ docker_network_name }}"
+  when: validator_client == 'lighthouse'
+  tags:
+    - validator
+    - validator-client
+    - lighthouse
+    - deploy

--- a/roles/validator_client/tasks/main.yml
+++ b/roles/validator_client/tasks/main.yml
@@ -198,7 +198,7 @@
       NETWORK: "{{ beacon_network }}"
       BUILDER_API_ENABLED: "{{ validator_builder_api_enabled }}"
       FEE_RECIPIENT: "{{ validator_fee_recipient }}"
-      LIGHTHOUSE_METRICS_PORT: "{{ vc_lighthouse_metrics_port }}"
+      LIGHTHOUSE_METRICS_PORT: "{{ vc_lighthouse_metrics_port | string }}"
     volumes:
       - "{{ validator_client_data_dir }}/lighthouse-run.sh:/opt/lighthouse/run.sh"
       - "{{ validator_keys_path }}:/opt/charon/validator_keys"


### PR DESCRIPTION
## Summary

Major update to obol-ansible: adds full-stack deployment (EL+CL+Charon+VC+MEV-boost+Prometheus+Alloy), bumps all client versions to latest, adds CI smoke tests, and fixes multiple bugs.

### Version bumps
Geth v1.17.2, Nethermind 1.36.2, Besu 26.2.0, Reth v1.11.3, Lighthouse v8.1.3, Teku 26.4.0, Lodestar v1.41.1, Nimbus multiarch-v26.3.1, Prysm v7.1.3, Grandine 2.0.4

### Bug fixes
- Besu: removed deprecated `--engine-rpc-host` flag (v26 breaking change)
- Lighthouse VC: `metrics_port` int→string for Docker env
- Prysm BN: added missing metrics port/flags
- Prysm VC: added `exec`, fixed hardcoded wallet password, removed deprecated flags
- Nimbus VC: `rm -rf` targeted to validators/db only (was wiping entire data dir)
- Lighthouse VC: added `--init-slashing-protection`
- Charon: `recreate: false`, `changed_when: false` on read-only tasks
- File permissions: 777→600 on validator keys and private keys
- JWT permissions: 0600→0644 (readable by non-root CL containers like Nimbus)
- docker_install: dynamic Ubuntu release instead of hardcoded `focal`
- Playbook conditionals: added `| bool` filter

### CI Smoke tests
18 parallel jobs testing all supported EL/CL pairs with rotating VC clients. Uses `ansible-playbook charon-node.yml` with real Charon cluster artifacts. Python log analysis detects startup errors (wrong flags, missing files, permissions).

ticket: none