### PR TITLE
fix: pin GitHub Actions to SHA for supply chain security

### DIFF
--- a/.github/workflows/add-issue-to-project.yaml
+++ b/.github/workflows/add-issue-to-project.yaml
@@ -14,7 +14,7 @@ jobs:
     # Steps
     steps:
       - name: Add Issue To Project
-        uses: actions/add-to-project@v1.0.2
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           # URL of the project to add issues to
           project-url: https://github.com/orgs/ObolNetwork/projects/7

--- a/.github/workflows/label-issue.yaml
+++ b/.github/workflows/label-issue.yaml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@v26
+        uses: ansible/ansible-lint@8ba9595a4acd1b906eb75568b34f6ef592cd1528 # v26


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions `uses:` references to commit SHAs for supply chain security
- Original version tags preserved as inline comments for maintainability
- Mitigates supply chain attacks where a compromised tag could inject malicious code (ref: Trivy incident March 2026)

## Changes
- All `uses: owner/action@tag` → `uses: owner/action@SHA # tag`
- No version changes, only pinning format

## Test plan
- [x] Verify CI workflows run successfully
- [x] Confirm no action versions changed, only pinning format