### PR TITLE
fix: charon_node role path resolution and file permissions

### DIFF
--- a/roles/charon_node/tasks/main.yml
+++ b/roles/charon_node/tasks/main.yml
@@ -44,7 +44,7 @@
     remote_src: false
     src: '{{ lock_file }}'
     dest: "{{ validator_base_dir }}/"
-    mode: '0644'
+    mode: '0640'
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
   tags:

--- a/roles/charon_node/tasks/main.yml
+++ b/roles/charon_node/tasks/main.yml
@@ -1,8 +1,10 @@
 - name: Create charon-node directory
   ansible.builtin.file:
-    path: ~/node-{{ node_index }}
+    path: "{{ validator_base_dir }}"
     state: directory
-    mode: '775'
+    mode: '0755'
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
   tags:
     - charon
     - charon-node
@@ -13,8 +15,10 @@
     remote_src: false
     directory_mode: true
     src: '{{ validator_keys_dir }}'
-    dest: ~/node-{{ node_index }}/
-    mode: '600'
+    dest: "{{ validator_base_dir }}/"
+    mode: '0600'
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
   tags:
     - charon
     - charon-node
@@ -25,8 +29,10 @@
   ansible.builtin.copy:
     remote_src: false
     src: '{{ private_key_file }}'
-    dest: ~/node-{{ node_index }}/
-    mode: '600'
+    dest: "{{ validator_base_dir }}/"
+    mode: '0600'
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
   tags:
     - charon
     - charon-node
@@ -37,35 +43,10 @@
   ansible.builtin.copy:
     remote_src: false
     src: '{{ lock_file }}'
-    dest: ~/node-{{ node_index }}/
-    mode: '644'
-  tags:
-    - charon
-    - charon-node
-    - configuration
-
-- name: Retrieve full path of validator keys
-  ansible.builtin.command: realpath ~/node-{{ node_index }}/validator_keys
-  register: validator_keys
-  changed_when: false
-  tags:
-    - charon
-    - charon-node
-    - configuration
-
-- name: Retrieve full path of private key
-  ansible.builtin.command: realpath ~/node-{{ node_index }}/charon-enr-private-key
-  register: private_key
-  changed_when: false
-  tags:
-    - charon
-    - charon-node
-    - configuration
-
-- name: Retrieve full path of cluster lock
-  ansible.builtin.command: realpath ~/node-{{ node_index }}/cluster-lock.json
-  register: cluster_lock
-  changed_when: false
+    dest: "{{ validator_base_dir }}/"
+    mode: '0644'
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
   tags:
     - charon
     - charon-node
@@ -88,9 +69,9 @@
     recreate: false
     command: run
     volumes:
-      - '{{ validator_keys.stdout }}:/charon/validator_keys'
-      - '{{ private_key.stdout }}:/charon/charon-enr-private-key'
-      - '{{ cluster_lock.stdout }}:/charon/cluster-lock.json'
+      - '{{ validator_base_dir }}/validator_keys:/charon/validator_keys'
+      - '{{ validator_base_dir }}/charon-enr-private-key:/charon/charon-enr-private-key'
+      - '{{ validator_base_dir }}/cluster-lock.json:/charon/cluster-lock.json'
     env:
       CHARON_BEACON_NODE_ENDPOINTS: '{{ beacon_node_endpoints | default(omit) }}'
       CHARON_BUILDER_API: '{{ builder_api | default(omit) }}'


### PR DESCRIPTION
## Summary

Fixes #75.

- Replace `~/node-{{ node_index }}` with `{{ validator_base_dir }}` in all `charon_node` tasks. With `become: true`, `~` resolved to `/root/`, placing artifacts in an inaccessible directory (`/root/` is mode `700`).
- Set `owner`/`group` to `{{ ansible_user }}` on all copy tasks so the charon container user (UID 1000) can read the bind-mounted files. Matches the pattern `validator_client` already uses.
- Remove three `realpath` shell-out tasks that only existed to resolve `~` to an absolute path for Docker volume mounts. `validator_base_dir` is already absolute.

## Test plan

- [x] Deployed full stack (Nethermind + Lighthouse + Charon + Nimbus VC + MEV-boost + Prometheus + Alloy) to a remote Ubuntu host via SSH
- [x] Verified charon starts successfully and connects to the beacon node (previously failed with `permission denied` reading the ENR private key)
- [x] Verified all other containers remain healthy